### PR TITLE
chore: response API standardization

### DIFF
--- a/cmd/api/responseTypes.go
+++ b/cmd/api/responseTypes.go
@@ -2,9 +2,9 @@ package main
 
 import "github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
 
-// InstanceListResponse represents the API response containing a list of clusters
+// InstanceListResponse represents the API response containing a list of instances
 type InstanceListResponse struct {
-	Count     int                  `json:"count"`
+	Count     int                  `json:"count,omitempty"`
 	Instances []inventory.Instance `json:"instances"`
 }
 
@@ -13,14 +13,17 @@ type InstanceListResponse struct {
 func NewInstanceListResponse(instances []inventory.Instance) *InstanceListResponse {
 	numInstances := len(instances)
 
-	// If there is no clusters, an empty array is returned instead of null
+	// If there is no instances, an empty array is returned instead of null
 	if numInstances == 0 {
 		instances = []inventory.Instance{}
 	}
 
 	response := InstanceListResponse{
-		Count:     numInstances,
 		Instances: instances,
+	}
+	// If there is more than one instance, the response contains a 'count' field
+	if numInstances > 1 {
+		response.Count = numInstances
 	}
 
 	return &response
@@ -28,7 +31,7 @@ func NewInstanceListResponse(instances []inventory.Instance) *InstanceListRespon
 
 // ClusterListResponse represents the API response containing a list of clusters
 type ClusterListResponse struct {
-	Count    int                 `json:"count"`
+	Count    int                 `json:"count,omitempty"`
 	Clusters []inventory.Cluster `json:"clusters"`
 }
 
@@ -43,8 +46,11 @@ func NewClusterListResponse(clusters []inventory.Cluster) *ClusterListResponse {
 	}
 
 	response := ClusterListResponse{
-		Count:    numClusters,
 		Clusters: clusters,
+	}
+	// If there is more than one cluster, the response contains a 'count' field
+	if numClusters > 1 {
+		response.Count = numClusters
 	}
 
 	return &response
@@ -52,7 +58,7 @@ func NewClusterListResponse(clusters []inventory.Cluster) *ClusterListResponse {
 
 // AccountListResponse represents the API response containing a list of accounts
 type AccountListResponse struct {
-	Count    int                 `json:"count"`
+	Count    int                 `json:"count,omitempty"`
 	Accounts []inventory.Account `json:"accounts"`
 }
 
@@ -67,8 +73,11 @@ func NewAccountListResponse(accounts []inventory.Account) *AccountListResponse {
 	}
 
 	response := AccountListResponse{
-		Count:    numAccounts,
 		Accounts: accounts,
+	}
+	// If there is more than one account, the response contains a 'count' field
+	if numAccounts > 1 {
+		response.Count = numAccounts
 	}
 
 	return &response


### PR DESCRIPTION
A new API response logic:

- If number of elements = 0, return an empty array.
- If the number of elements > 1, return an array with the "count" field.
- In other cases, return an array without the "count" field.