### PR TITLE
chore: add health checks, pgsql volume

### DIFF
--- a/deployments/docker-compose/docker-compose.yaml
+++ b/deployments/docker-compose/docker-compose.yaml
@@ -7,17 +7,18 @@ services:
     ports:
       - 8080:8080
     environment:
-      CIQ_API_URL: "http://api:8443/api/v1"
+      CIQ_API_URL: "http://api:8080/api/v1"
   api:
     image: quay.io/ecosystem-appeng/cluster-iq-api:latest
     container_name: api
     restart: always
     depends_on:
-      - pgsql
+      pgsql:
+        condition: service_healthy
     ports:
-      - 9000:9000
+      - 8081:8080
     environment:
-      CIQ_API_URL: "0.0.0.0:8443"
+      CIQ_API_URL: "0.0.0.0:8080"
       CIQ_DB_URL: "postgresql://user:password@pgsql:5432/clusteriq?sslmode=disable"
       CIQ_LOG_LEVEL: "DEBUG"
 
@@ -26,9 +27,10 @@ services:
     container_name: scanner
     restart: "no"
     depends_on:
-      - pgsql
+      pgsql:
+        condition: service_healthy
     environment:
-      CIQ_API_URL: "http://api:8443/api/v1"
+      CIQ_API_URL: "http://api:8080/api/v1"
       CIQ_CREDS_FILE: "/credentials"
       CIQ_LOG_LEVEL: "DEBUG"
     volumes:
@@ -45,7 +47,13 @@ services:
       POSTGRESQL_PASSWORD: "password"
       POSTGRESQL_DATABASE: "clusteriq"
       POSTGRESQL_ADMIN_PASSWORD: "admin"
-
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - db:/var/lib/pgsql/data
   init-pgsql:
     image: registry.redhat.io/rhel8/postgresql-12@sha256:a6230cba71eb33e67fffc21161929de4bc618bc5e2f21fbec3c4c227205c2061
     container_name: init-pgsql
@@ -56,4 +64,7 @@ services:
       - ./../../db/sql/init.sql:/init.sql
     depends_on:
       pgsql:
-        condition: service_started
+        condition: service_healthy
+volumes:
+  db:
+    driver: local


### PR DESCRIPTION
List of changes:

- Refactor to use standard port (8080) for all services (API and Console).
- Add a health check for the PostgreSQL to determine whether the service containers are "healthy."
- Update dependencies to start services only after PostgreSQL is "healthy."