### PR TITLE
fix: remove unused handler body parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,11 @@ cover: test
 
 # Swagger
 swagger-editor:
-	@echo "Open your browser at http://localhost:8081"
-	@$(CONTAINER_ENGINE) run -p 8081:8080 -e SWAGGER_FILE=/open_api_design.yaml -v ./open_api_design.yaml:/open_api_design.yaml swaggerapi/swagger-editor
+	@echo "Open your browser at http://127.0.0.1:8082"
+	@$(CONTAINER_ENGINE) run --rm -p 127.0.0.1:8082:8080 \
+		-e SWAGGER_FILE=/tmp/swagger.yaml \
+		-v ./cmd/api/docs/swagger.yaml:/tmp/swagger.yaml:Z \
+		swaggerapi/swagger-editor
 
 swagger-doc:
 	@echo "### [Generating Swagger Docs] ###"

--- a/cmd/api/api_server.go
+++ b/cmd/api/api_server.go
@@ -89,10 +89,10 @@ func addHeaders(c *gin.Context) {
 //	@title			ClusterIQ API
 //	@version		1.0
 //	@description	This is the API of the ClusterIQ cloud inventory software
-//	@tersOfService	http://swagger.io/ters/
+//	@termsOfService	http://swagger.io/terms/
 
 //	@contact.name	ClusterIQ Team
-//	@contact.email	vbelouso@redhat.com nnaamneh@redhat.com avillega@redhat.com
+//	@contact.email	cloud-native-team@redhat.com
 
 //	@license.name	Apache 2.0
 //	@license.url	http://www.apache.org/licenses/LICENSE-2.0.html

--- a/cmd/api/handlers.go
+++ b/cmd/api/handlers.go
@@ -536,7 +536,7 @@ func HandlerGetClustersOnAccount(c *gin.Context) {
 //	@Tags			Accounts
 //	@Accept			json
 //	@Produce		json
-//	@Param			account	body		inventory.Account	true	"New Account to be added"	Format(email)
+//	@Param			account	body		inventory.Account	true	"New Account to be added"
 //	@Success		200		{object}	nil
 //	@Failure		500		{object}	nil
 //	@Router			/accounts/ [post]


### PR DESCRIPTION
- Updated swagger-editor to use port `8082` to prevent conflicts with the API server.
- Removed unused parameter from the handler to resolve the error.

```text
Structural error at paths./accounts/.post.parameters.0
should NOT have additional properties
additionalProperty: format
```

- Updated `@contact.email` to the group address because `@contact.email` cannot be used as a list.
```text
Structural error at info.contact.email
should match format "email"
format: email
```