### PR TITLE
feat: cloud provider lib implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ restart-dev: stop-dev start-dev
 
 
 # Tests targets
+.PHONY: test
 test:
 	@[[ -d $(TEST_DIR) ]] || mkdir $(TEST_DIR)
 	@go test -race ./... -coverprofile $(TEST_DIR)/cover.out

--- a/internal/cloud_agent/aws.go
+++ b/internal/cloud_agent/aws.go
@@ -1,0 +1,26 @@
+package cloudagent
+
+import (
+	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"go.uber.org/zap"
+)
+
+// AWSAgent implements the CloudAgent interface for AWS
+type AWSAgent struct {
+	account *inventory.Account
+	session *session.Session
+	logger  *zap.Logger
+}
+
+func NewAWSAgent(account *inventory.Account, logger *zap.Logger) *AWSAgent {
+	return &AWSAgent{
+		account: account,
+		session: nil,
+		logger:  logger,
+	}
+}
+
+func (a *AWSAgent) Connect() error {
+
+}

--- a/internal/cloud_agent/cloud_agent.go
+++ b/internal/cloud_agent/cloud_agent.go
@@ -1,0 +1,9 @@
+package cloudagent
+
+// CloudAgent interface
+type CloudAgent interface {
+	// Connect logs in into the cloud provider
+	Connect()
+	PowerOffCluster()
+	PowerOnCluster()
+}

--- a/internal/cloud_providers/aws/aws-cost-explorer.go
+++ b/internal/cloud_providers/aws/aws-cost-explorer.go
@@ -1,0 +1,30 @@
+package cloudprovider
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+)
+
+// AWSCostExplorerConnection represents the client object for the CostExplorer service
+type AWSCostExplorerConnection struct {
+	client *costexplorer.CostExplorer
+}
+
+// NewAWSCostExplorerConnection creates a new AWSCostExplorerConnection object
+func NewAWSCostExplorerConnection(session *session.Session) *AWSCostExplorerConnection {
+	return &AWSCostExplorerConnection{
+		client: costexplorer.New(session),
+	}
+}
+
+// WithCostExplorer configures an AWSConnection instance for including the CostExplorer client
+func WithCostExplorer() AWSConnectionOption {
+	return func(conn *AWSConnection) {
+		conn.STS = NewAWSSTSConnection(conn.awsSession)
+	}
+}
+
+// GetCostAndUsageWithResources obtains a list of expenses based on the input config
+func (c *AWSCostExplorerConnection) GetCostAndUsageWithResources(input *costexplorer.GetCostAndUsageWithResourcesInput) (*costexplorer.GetCostAndUsageWithResourcesOutput, error) {
+	return c.client.GetCostAndUsageWithResources(input)
+}

--- a/internal/cloud_providers/aws/aws-ec2.go
+++ b/internal/cloud_providers/aws/aws-ec2.go
@@ -1,0 +1,89 @@
+package cloudprovider
+
+import (
+	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// AWSEC2Connection represents the EC2 client for AWS
+type AWSEC2Connection struct {
+	client *ec2.EC2
+}
+
+// Creates a new EC2 client instance based on an AWSSession
+func NewAWSEC2Connection(session *session.Session) *AWSEC2Connection {
+	return &AWSEC2Connection{
+		client: ec2.New(session),
+	}
+}
+
+// WithEC2 configures an AWSConnection instance for including the EC2 client
+func WithEC2() AWSConnectionOption {
+	return func(conn *AWSConnection) {
+		conn.EC2 = NewAWSEC2Connection(conn.awsSession)
+	}
+}
+
+// GetRegionsList returns a list of the available AWS regions as a string array
+func (c *AWSEC2Connection) GetRegionsList() ([]string, error) {
+	// Getting regions from AWS API
+	regions, err := c.client.DescribeRegions(&ec2.DescribeRegionsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Converting to string array
+	regionList := make([]string, 0)
+
+	for _, region := range regions.Regions {
+		regionList = append(regionList, *region.RegionName)
+	}
+
+	return regionList, nil
+}
+
+// GetInstances gets the list of EC2 instances and returns them as an Array if Inventory.Instances
+func (c *AWSEC2Connection) GetInstances() ([]inventory.Instance, error) {
+	// Getting Instances list
+	reservations, err := c.client.DescribeInstances(&ec2.DescribeInstancesInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Converting EC2 instances to inventory.Instance
+	var instances []inventory.Instance
+	for _, reser := range reservations.Reservations {
+		for _, instance := range reser.Instances {
+			instances = append(instances, *EC2InstanceToInventoryInstance(instance))
+		}
+	}
+
+	return instances, nil
+}
+
+// EC2InstanceToInventoryInstance converts an EC2.instance into an inventory.Instance
+func EC2InstanceToInventoryInstance(instance *ec2.Instance) *inventory.Instance {
+	// Getting Instance properties
+	id := *instance.InstanceId
+	tags := ConvertEC2TagtoTag(instance.Tags, id)
+	name := inventory.GetInstanceNameFromTags(tags)
+	provider := inventory.AWSProvider
+	instanceType := *instance.InstanceType
+	availabilityZone := *instance.Placement.AvailabilityZone
+	status := inventory.AsInstanceStatus(*instance.State.Name)
+	clusterID := inventory.GetClusterIDFromTags(tags)
+	creationTimestamp := *instance.LaunchTime
+
+	return inventory.NewInstance(
+		id,
+		name,
+		provider,
+		instanceType,
+		availabilityZone,
+		status,
+		clusterID,
+		tags,
+		creationTimestamp,
+	)
+}

--- a/internal/cloud_providers/aws/aws-route53.go
+++ b/internal/cloud_providers/aws/aws-route53.go
@@ -1,0 +1,82 @@
+package cloudprovider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+const ()
+
+type AWSRoute53Connection struct {
+	client *route53.Route53
+}
+
+func NewAWSRoute53Connection(session *session.Session) *AWSRoute53Connection {
+	return &AWSRoute53Connection{
+		client: route53.New(session),
+	}
+}
+
+// WithRoute53 configures an AWSConnection instance for including the Route53 client
+func WithRoute53() AWSConnectionOption {
+	return func(conn *AWSConnection) {
+		conn.Route53 = NewAWSRoute53Connection(conn.awsSession)
+	}
+}
+
+// getRoute53HostedZones get a list of every Hosted Zone on the Route53 service
+func (c *AWSRoute53Connection) GetRoute53HostedZones() ([]*route53.HostedZone, error) {
+	input := route53.ListHostedZonesByNameInput{}
+	result, err := c.client.ListHostedZonesByName(&input)
+	if err != nil {
+		return nil, err
+	}
+	return result.HostedZones, nil
+}
+
+// CheckIfHostedZoneBelongsToCluster returns true or false if the hosted zone is associated to a cluster Ingress (routers)
+func (c *AWSRoute53Connection) CheckIfHostedZoneBelongsToCluster(cluster *inventory.Cluster, hostedZone *route53.HostedZone) bool {
+	hztype := route53.TagResourceTypeHostedzone
+	output, err := c.client.ListTagsForResource(&route53.ListTagsForResourceInput{
+		ResourceType: &hztype,
+		ResourceId:   aws.String(*hostedZone.Id),
+	})
+	if err != nil {
+		return false
+	}
+
+	for _, tag := range output.ResourceTagSet.Tags {
+		if strings.Contains(*(tag.Key), cluster.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetHostedZoneRecords returns every record of a given HostedZone
+func (c *AWSRoute53Connection) GetHostedZoneRecords(hostedZoneID string) ([]*route53.ResourceRecordSet, error) {
+	// Define input for ListResourceRecordSets
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(hostedZoneID),
+	}
+
+	var records []*route53.ResourceRecordSet
+
+	// API Call for getting DNS records
+	err := c.client.ListResourceRecordSetsPages(input, func(page *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
+		records = append(records, page.ResourceRecordSets...)
+		return !lastPage // Continue if there are more record pages
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("Error getting the DNS registries: %v", err)
+	}
+
+	return records, nil
+
+}

--- a/internal/cloud_providers/aws/aws-route53.go
+++ b/internal/cloud_providers/aws/aws-route53.go
@@ -68,10 +68,11 @@ func (c *AWSRoute53Connection) GetHostedZoneRecords(hostedZoneID string) ([]*rou
 	var records []*route53.ResourceRecordSet
 
 	// API Call for getting DNS records
-	err := c.client.ListResourceRecordSetsPages(input, func(page *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
-		records = append(records, page.ResourceRecordSets...)
-		return !lastPage // Continue if there are more record pages
-	})
+	err := c.client.ListResourceRecordSetsPages(input,
+		func(page *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
+			records = append(records, page.ResourceRecordSets...)
+			return !lastPage // Continue if there are more record pages
+		})
 
 	if err != nil {
 		return nil, fmt.Errorf("Error getting the DNS registries: %v", err)

--- a/internal/cloud_providers/aws/aws-sts.go
+++ b/internal/cloud_providers/aws/aws-sts.go
@@ -1,0 +1,36 @@
+package cloudprovider
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+const unknownAccountIDCode = "Unknown_Account_ID"
+
+type AWSSTSConnection struct {
+	client *sts.STS
+}
+
+func NewAWSSTSConnection(session *session.Session) *AWSSTSConnection {
+	return &AWSSTSConnection{
+		client: sts.New(session),
+	}
+}
+
+func (c *AWSSTSConnection) getAWSAccountID() string {
+	input := &sts.GetCallerIdentityInput{}
+
+	req, err := c.client.GetCallerIdentity(input)
+	if err != nil {
+		return unknownAccountIDCode
+	}
+
+	return *req.Account
+}
+
+// WitSTS configures an AWSConnection instance for including the STS client
+func WithSTS() AWSConnectionOption {
+	return func(conn *AWSConnection) {
+		conn.STS = NewAWSSTSConnection(conn.awsSession)
+	}
+}

--- a/internal/cloud_providers/aws/aws-tags.go
+++ b/internal/cloud_providers/aws/aws-tags.go
@@ -1,0 +1,15 @@
+package cloudprovider
+
+import (
+	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// ConvertEC2TagtoTag transforms the EC2 instance tags into inventory Tag
+func ConvertEC2TagtoTag(ec2Tags []*ec2.Tag, instanceID string) []inventory.Tag {
+	var tags []inventory.Tag
+	for _, tag := range ec2Tags {
+		tags = append(tags, *inventory.NewTag(*tag.Key, *tag.Value, instanceID))
+	}
+	return tags
+}

--- a/internal/cloud_providers/aws/aws.go
+++ b/internal/cloud_providers/aws/aws.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"go.uber.org/zap"
 )
 
 const (
@@ -26,14 +25,13 @@ type AWSConnection struct {
 	user         string
 	password     string
 	region       string
-	logger       *zap.Logger
 }
 
 // AWSConnectionOption defines the options for creating different sets of AWS services connections
 type AWSConnectionOption func(*AWSConnection)
 
 // NewAWSConnection creates a connection with AWS APIs. Based on the AWSConnectionOptions, it will create different clients for every available service
-func NewAWSConnection(user string, password string, region string, looger *zap.Logger, opts ...AWSConnectionOption) (*AWSConnection, error) {
+func NewAWSConnection(user string, password string, region string, opts ...AWSConnectionOption) (*AWSConnection, error) {
 	var token string = ""
 
 	// If there's no region specified, it will take the default one.

--- a/internal/cloud_providers/aws/aws.go
+++ b/internal/cloud_providers/aws/aws.go
@@ -40,19 +40,10 @@ func NewAWSConnection(user string, password string, region string, opts ...AWSCo
 	}
 
 	// Third argument (token) it's not used. For more info check docs: https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/credentials#NewStaticCredentials
-	credentials := credentials.NewStaticCredentials(user, password, token)
-	if credentials == nil {
-		return nil, fmt.Errorf("Cannot load StaticCredentials for AWS Cloud Provider")
-	}
+	creds := credentials.NewStaticCredentials(user, password, token)
 
 	conn := &AWSConnection{
-		credentials: credentials,
-		awsConfig:   nil,
-		awsSession:  nil,
-		EC2:         nil,
-		Route53:     nil,
-		STS:         nil,
-		accountID:   "",
+		credentials: creds,
 		user:        user,
 		password:    password,
 		region:      region,
@@ -73,7 +64,7 @@ func NewAWSConnection(user string, password string, region string, opts ...AWSCo
 		opt(conn)
 	}
 
-	// If the STS service was enabled, get the accountID for fullfilling the data
+	// If the STS service was enabled, get the accountID for fulfilling the data
 	if conn.STS != nil {
 		conn.accountID = conn.STS.getAWSAccountID()
 	}
@@ -121,7 +112,7 @@ func (conn *AWSConnection) GetAccountID() string {
 	return conn.accountID
 }
 
-// Connect stablish or refresh the AWS service clients for the AWSConnection
+// Connect establish or refresh the AWS service clients for the AWSConnection
 // object. This is needed because some clients needs to be re-created when
 // switching to a different region
 func (conn *AWSConnection) Connect() error {

--- a/internal/cloud_providers/aws/aws.go
+++ b/internal/cloud_providers/aws/aws.go
@@ -1,0 +1,162 @@
+package cloudprovider
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"go.uber.org/zap"
+)
+
+const (
+	// Default Region for AWS CLI
+	DefaultAWSRegion = "eu-west-1"
+)
+
+type AWSConnection struct {
+	credentials  *credentials.Credentials
+	awsConfig    *aws.Config
+	awsSession   *session.Session
+	EC2          *AWSEC2Connection
+	Route53      *AWSRoute53Connection
+	STS          *AWSSTSConnection
+	CostExplorer *AWSCostExplorerConnection
+	accountID    string
+	user         string
+	password     string
+	region       string
+	logger       *zap.Logger
+}
+
+// AWSConnectionOption defines the options for creating different sets of AWS services connections
+type AWSConnectionOption func(*AWSConnection)
+
+// NewAWSConnection creates a connection with AWS APIs. Based on the AWSConnectionOptions, it will create different clients for every available service
+func NewAWSConnection(user string, password string, region string, looger *zap.Logger, opts ...AWSConnectionOption) (*AWSConnection, error) {
+	var token string = ""
+
+	// If there's no region specified, it will take the default one.
+	if region == "" {
+		region = DefaultAWSRegion
+	}
+
+	// Third argument (token) it's not used. For more info check docs: https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/credentials#NewStaticCredentials
+	credentials := credentials.NewStaticCredentials(user, password, token)
+	if credentials == nil {
+		return nil, fmt.Errorf("Cannot load StaticCredentials for AWS Cloud Provider")
+	}
+
+	conn := &AWSConnection{
+		credentials: credentials,
+		awsConfig:   nil,
+		awsSession:  nil,
+		EC2:         nil,
+		Route53:     nil,
+		STS:         nil,
+		accountID:   "",
+		user:        user,
+		password:    password,
+		region:      region,
+	}
+
+	// creating AWSConfig object
+	if err := conn.newAWSConfig(); err != nil {
+		return nil, err
+	}
+
+	// creating AWSSession
+	if err := conn.newAWSession(); err != nil {
+		return nil, err
+	}
+
+	// Apply options for every service to the AWSConnection object
+	for _, opt := range opts {
+		opt(conn)
+	}
+
+	// If the STS service was enabled, get the accountID for fullfilling the data
+	if conn.STS != nil {
+		conn.accountID = conn.STS.getAWSAccountID()
+	}
+
+	return conn, nil
+}
+
+// newAWSConfig creates a new AWSConfig object instance to define the AWSSession config
+func (conn *AWSConnection) newAWSConfig() error {
+	// Preparing AWSConfig for new AWS API Session
+	conn.awsConfig = aws.NewConfig().WithCredentials(conn.credentials).WithRegion(conn.region)
+	if conn.awsConfig == nil {
+		return fmt.Errorf("Cannot obtain AWS config for Account: %s\n", conn.accountID)
+	}
+
+	return nil
+}
+
+// newAWSession creates a new AWSSession
+func (conn *AWSConnection) newAWSession() error {
+	var err error
+
+	// Creating Session for AWS API
+	conn.awsSession, err = session.NewSession(conn.awsConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetRegion returns the current region configured for the AWS Connection
+func (conn AWSConnection) GetRegion() string {
+	return conn.region
+}
+
+// SetRegion configures a new Region for the AWS Connection and refreshes the service clients for the new target region
+func (conn *AWSConnection) SetRegion(region string) error {
+	conn.region = region
+	return conn.Connect()
+}
+
+// GetAccountID returns the accountID obtained from AWS for the account on the current AWSConnection
+func (conn *AWSConnection) GetAccountID() string {
+	return conn.accountID
+}
+
+// Connect stablish or refresh the AWS service clients for the AWSConnection
+// object. This is needed because some clients needs to be re-created when
+// switching to a different region
+func (conn *AWSConnection) Connect() error {
+	var err error
+
+	// Creating new AWS Config
+	err = conn.newAWSConfig()
+	if err != nil {
+		return err
+	}
+
+	// Creating new AWS Session
+	err = conn.newAWSession()
+	if err != nil {
+		return err
+	}
+
+	// Refreshing service client objects for the AWS Connection
+	if conn.EC2 != nil {
+		WithEC2()(conn)
+	}
+
+	if conn.Route53 != nil {
+		WithRoute53()(conn)
+	}
+
+	if conn.STS != nil {
+		WithSTS()(conn)
+	}
+
+	if conn.CostExplorer != nil {
+		WithCostExplorer()(conn)
+	}
+
+	return nil
+}

--- a/internal/cloud_providers/cloud_provider.go
+++ b/internal/cloud_providers/cloud_provider.go
@@ -1,0 +1,6 @@
+package cloudprovider
+
+// TODO DOC
+type CloudProviderConnection interface {
+	Connect()
+}

--- a/internal/cloud_providers/cloud_provider.go
+++ b/internal/cloud_providers/cloud_provider.go
@@ -1,6 +1,7 @@
 package cloudprovider
 
-// TODO DOC
+// CloudProviderConnection defines the interface that every cloud
+// provider should implement to be compatible with ClusterIQ
 type CloudProviderConnection interface {
 	Connect()
 }

--- a/internal/config/agent_config.go
+++ b/internal/config/agent_config.go
@@ -1,0 +1,19 @@
+package config
+
+import env "github.com/caarlos0/env/v11"
+
+// AgentConfig defines the config parameters for the ClusterIQ Agent
+type AgentConfig struct {
+	Credentials CloudCredentialsConfig
+	ListenURL   string `env:"CIQ_API_LISTEN_URL,required"`
+}
+
+// LoadAgentConfig evaluates and return the AgentConfig object
+func LoadAgentConfig() (*AgentConfig, error) {
+	cfg := &AgentConfig{}
+	err := env.Parse(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/internal/config/api_config.go
+++ b/internal/config/api_config.go
@@ -1,0 +1,19 @@
+package config
+
+import env "github.com/caarlos0/env/v11"
+
+// APIServerConfig defines the config parameters for the ClusterIQ API
+type APIServerConfig struct {
+	ListenURL string `env:"CIQ_API_LISTEN_URL,required"`
+	DBURL     string `env:"CIQ_DB_URL,required"`
+}
+
+// LoadAPIServerConfig evaluates and return the APIServerConfig Object
+func LoadAPIServerConfig() (*APIServerConfig, error) {
+	cfg := &APIServerConfig{}
+	err := env.Parse(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,38 +1,6 @@
 package config
 
-import (
-	"github.com/caarlos0/env/v11"
-)
-
-type CommonConfig struct {
+// CloudCredentialsConfig represents the config parameters for obtaining the Cloud Provier Credentials
+type CloudCredentialsConfig struct {
 	CredentialsFile string `env:"CIQ_CREDS_FILE,required"`
-}
-
-type ScannerConfig struct {
-	CommonConfig
-	APIURL string `env:"CIQ_API_URL,required"`
-}
-
-type APIServerConfig struct {
-	CommonConfig
-	ListenURL string `env:"CIQ_API_LISTEN_URL,required"`
-	DBURL     string `env:"CIQ_DB_URL,required"`
-}
-
-func LoadScannerConfig() (*ScannerConfig, error) {
-	cfg := &ScannerConfig{}
-	err := env.Parse(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-func LoadAPIServerConfig() (*APIServerConfig, error) {
-	cfg := &APIServerConfig{}
-	err := env.Parse(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }

--- a/internal/config/scanner_config.go
+++ b/internal/config/scanner_config.go
@@ -1,0 +1,19 @@
+package config
+
+import env "github.com/caarlos0/env/v11"
+
+// ScannerConfig defines the config parameters for the ClusterIQ Scanner
+type ScannerConfig struct {
+	CloudCredentialsConfig
+	APIURL string `env:"CIQ_API_URL,required"`
+}
+
+// LoadScannerConfig evaluates and return the ScannerConfig object
+func LoadScannerConfig() (*ScannerConfig, error) {
+	cfg := &ScannerConfig{}
+	err := env.Parse(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/internal/inventory/cluster.go
+++ b/internal/inventory/cluster.go
@@ -7,16 +7,16 @@ import (
 )
 
 const (
-	// minInstances represents the minimum number of instances for evaulating a
+	// minInstances represents the minimum number of instances for evaluating a
 	// cluster and its status.  Openshift it's not supported if the amount of
 	// Master nodes is different than 3, so it's a good guideline for defining
-	// the minimun number of instances
+	// the minimum number of instances
 	minInstances int = 3
 )
 
 // Cluster is the object to store Openshift Clusters and its properties
 type Cluster struct {
-	// ID is the uniq key to idenfity every cluster independently of which account it belongs
+	// ID is the unique key to identify every cluster independently of which account it belongs
 	// Its built as "name+infra_id+account"
 	ID string `db:"id" json:"id"`
 
@@ -50,7 +50,7 @@ type Cluster struct {
 	// Timestamp when the cluster was created
 	CreationTimestamp time.Time `db:"creation_timestamp" json:"creationTimestamp"`
 
-	// Ammount of days since the cluster was created
+	// Amount of days since the cluster was created
 	Age int `db:"age" json:"age"`
 
 	// Cluster's owner
@@ -106,7 +106,7 @@ func (c Cluster) isClusterRunning() bool {
 	return false
 }
 
-// UpdateClusterInfo as a update funciton wrapper
+// UpdateClusterInfo as a update function wrapper
 func (c *Cluster) Update() error {
 	var err error
 
@@ -155,7 +155,7 @@ func (c *Cluster) UpdateCosts() error {
 	}
 
 	if c.TotalCost < newCost {
-		return fmt.Errorf("New estimated cost is lower than exspected. Review the cluster/instanes costs. Current Cost: %f, New estimated cost: %f", c.TotalCost, newCost)
+		return fmt.Errorf("New estimated cost is lower than expected. Review the cluster/instances costs. Current Cost: %f, New estimated cost: %f", c.TotalCost, newCost)
 	}
 
 	c.TotalCost = newCost

--- a/internal/inventory/cluster.go
+++ b/internal/inventory/cluster.go
@@ -6,7 +6,13 @@ import (
 	"time"
 )
 
-const minInstances int = 3
+const (
+	// minInstances represents the minimum number of instances for evaulating a
+	// cluster and its status.  Openshift it's not supported if the amount of
+	// Master nodes is different than 3, so it's a good guideline for defining
+	// the minimun number of instances
+	minInstances int = 3
+)
 
 // Cluster is the object to store Openshift Clusters and its properties
 type Cluster struct {

--- a/internal/inventory/tag.go
+++ b/internal/inventory/tag.go
@@ -1,6 +1,21 @@
 package inventory
 
-import "github.com/aws/aws-sdk-go/service/ec2"
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// Regular expresion for extracting the Cluster's Name configured by `openshift-installer` from AWS Tags
+	clusterNameRegexp = "kubernetes.io/cluster/(.*?)-.{5}$"
+	// Regular expresion for extracting the InfrastructureID configured by `openshift-installer` from AWS Tags
+	infraIDRegexp = "kubernetes.io/cluster/.*-(.{5}?)$"
+	// Regular expresion for extracting the InfrastructureID configured by `openshift-installer` from AWS Tags
+	clusterIDRegexp = "kubernetes.io/cluster/(.*)$"
+
+	unknownClusterNameCode = "UNKNOWN-CLUSTER"
+	unknownClusterIDCode   = "UNKNOWN-CLUSTER"
+)
 
 // Tag model generic tags as a Key-Value object
 type Tag struct {
@@ -19,11 +34,93 @@ func NewTag(key string, value string, instanceID string) *Tag {
 	return &Tag{Key: key, Value: value, InstanceID: instanceID}
 }
 
-// ConvertEC2TagtoTag transforms the EC2 instance tags into Tag
-func ConvertEC2TagtoTag(ec2Tags []*ec2.Tag, instanceID string) []Tag {
-	var tags []Tag
-	for _, tag := range ec2Tags {
-		tags = append(tags, *NewTag(*tag.Key, *tag.Value, instanceID))
+// lookForTagByKey looks for a Tag based on its Key and returns a pointer to it
+func LookForTagByKey(key string, tags []Tag) *Tag {
+	var resultTag Tag
+	for _, tag := range tags {
+		if tag.Key == key {
+			return &resultTag
+		}
 	}
-	return tags
+	return nil
+}
+
+// parseClusterName parses a Tag key to obtain the clusterName
+func parseClusterName(key string) string {
+	re := regexp.MustCompile(clusterNameRegexp)
+	res := re.FindAllStringSubmatch(key, 1)
+
+	// if there are no results, return empty string, if there are, return first match
+	if len(res) <= 0 {
+		return unknownClusterNameCode
+	}
+	return res[0][1]
+}
+
+// parseClusterName parses a Tag key to obtain the clusterName
+func parseClusterID(key string) string {
+	re := regexp.MustCompile(clusterNameRegexp)
+	res := re.FindAllStringSubmatch(key, 1)
+
+	// if there are no results, return empty string, if there are, return first match
+	if len(res) <= 0 {
+		return unknownClusterIDCode
+	}
+	return res[0][1]
+}
+
+// parseInfraID parses a Tag key to obtain the InfraID
+func parseInfraID(key string) string {
+	re := regexp.MustCompile(infraIDRegexp)
+	res := re.FindAllStringSubmatch(key, 1)
+
+	// if there are no results, return empty string, if there are, return first match
+	if len(res) <= 0 {
+		return ""
+	}
+	return res[0][1]
+}
+
+// GetOwnerFromTags looks for a tag with the key "Owner" and returns its value
+func GetOwnerFromTags(tags []Tag) string {
+	result := (LookForTagByKey("Owner", tags))
+	if result != nil {
+		return result.Key
+	}
+	return ""
+}
+
+func GetInstanceNameFromTags(tags []Tag) string {
+	result := (LookForTagByKey("Name", tags))
+	if result != nil {
+		return result.Key
+	}
+	return ""
+}
+
+func GetClusterIDFromTags(tags []Tag) string {
+	for _, tag := range tags {
+		if strings.Contains(tag.Key, ClusterTagKey) {
+			return parseClusterID(tag.Key)
+		}
+	}
+	return unknownClusterNameCode
+}
+
+func GetClusterNameFromTags(tags []Tag) string {
+	for _, tag := range tags {
+		if strings.Contains(tag.Key, ClusterTagKey) {
+			return parseClusterName(tag.Key)
+		}
+	}
+	return unknownClusterNameCode
+}
+
+func GetInfraIDFromTags(tags []Tag) string {
+	for _, tag := range tags {
+		if strings.Contains(tag.Key, ClusterTagKey) {
+			return parseInfraID(tag.Key)
+		}
+	}
+	return unknownClusterNameCode
 }

--- a/internal/inventory/types.go
+++ b/internal/inventory/types.go
@@ -1,6 +1,8 @@
 package inventory
 
-import "strings"
+import (
+	"strings"
+)
 
 // InstanceStatus defines the status of the instance
 type InstanceStatus string

--- a/internal/stocker/aws_billing.go
+++ b/internal/stocker/aws_billing.go
@@ -40,7 +40,7 @@ func NewAWSBillingStocker(account *inventory.Account, logger *zap.Logger, instan
 	}
 }
 
-// Connect Initialices the AWS API and CostExplorer sessions and clients
+// Connect initialices the AWS API and CostExplorer sessions and clients
 func (s *AWSBillingStocker) Connect() error {
 	s.logger.Info("AWS Session created", zap.String("account_id", s.Account.Name))
 	return nil
@@ -76,7 +76,6 @@ func (s *AWSBillingStocker) MakeStock() error {
 }
 
 // getInstanceExpenses gets from the AWS CostExplorer API the expenses of a given Instance.
-// TODO: change argument to array of *instances
 // TODO: Calculate date intervals
 func (s *AWSBillingStocker) getInstanceExpenses(instance *inventory.Instance) error {
 	// Logic for Setting the period to fetch the Expenses within

--- a/internal/stocker/aws_billing.go
+++ b/internal/stocker/aws_billing.go
@@ -26,7 +26,7 @@ type AWSBillingStocker struct {
 // NewAWSStocker create and returns a pointer to a new AWSStocker instance
 func NewAWSBillingStocker(account *inventory.Account, logger *zap.Logger, instances []inventory.Instance) *AWSBillingStocker {
 	// Leaving the region empty forces to the AWSConnection to use the default region until a new one is configured
-	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", logger, cp.WithCostExplorer())
+	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", cp.WithCostExplorer())
 	if err != nil {
 		logger.Error("Error creating a new AWSBillingStocker", zap.Error(err))
 		return nil

--- a/internal/stocker/aws_billing.go
+++ b/internal/stocker/aws_billing.go
@@ -23,7 +23,7 @@ type AWSBillingStocker struct {
 	Instances []inventory.Instance
 }
 
-// NewAWSStocker create and returns a pointer to a new AWSStocker instance
+// NewAWSBillingStocker create and returns a pointer to a new AWSBillingStocker instance
 func NewAWSBillingStocker(account *inventory.Account, logger *zap.Logger, instances []inventory.Instance) *AWSBillingStocker {
 	// Leaving the region empty forces to the AWSConnection to use the default region until a new one is configured
 	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", cp.WithCostExplorer())
@@ -46,7 +46,8 @@ func (s *AWSBillingStocker) Connect() error {
 	return nil
 }
 
-// MakeStock TODO
+// MakeStock implements the Stocker interface. It starts the Stocker main
+// process getting the expenses of the instances stored in the Stocker object
 func (s *AWSBillingStocker) MakeStock() error {
 	for i := range s.Account.Clusters {
 		cluster := s.Account.Clusters[i]
@@ -74,6 +75,7 @@ func (s *AWSBillingStocker) MakeStock() error {
 	return nil
 }
 
+// getInstanceExpenses gets from the AWS CostExplorer API the expenses of a given Instance.
 // TODO: change argument to array of *instances
 // TODO: Calculate date intervals
 func (s *AWSBillingStocker) getInstanceExpenses(instance *inventory.Instance) error {
@@ -138,12 +140,12 @@ func (s *AWSBillingStocker) getInstanceExpenses(instance *inventory.Instance) er
 	return nil
 }
 
-// TODO: doc
+// PrintStock prints the stock (account) of the AWSBillingStocker as a string
 func (s AWSBillingStocker) PrintStock() {
 	s.Account.PrintAccount()
 }
 
-// TODO: doc
+// GetResults returns the account configured for this stocker
 func (s AWSBillingStocker) GetResults() inventory.Account {
 	return *s.Account
 }

--- a/internal/stocker/aws_common.go
+++ b/internal/stocker/aws_common.go
@@ -1,19 +1,1 @@
 package stocker
-
-import (
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/service/sts"
-)
-
-func getAWSAccountID(session client.ConfigProvider) (string, error) {
-	client := sts.New(session)
-	input := &sts.GetCallerIdentityInput{}
-
-	req, err := client.GetCallerIdentity(input)
-	if err != nil {
-		return unknownAccountIDCode, err
-	}
-
-	return *req.Account, nil
-
-}

--- a/internal/stocker/aws_stocker.go
+++ b/internal/stocker/aws_stocker.go
@@ -1,89 +1,55 @@
 package stocker
 
 import (
-	"fmt"
-
+	cp "github.com/RHEcosystemAppEng/cluster-iq/internal/cloud_providers/aws"
 	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"go.uber.org/zap"
 )
 
 const (
-	// Default Region for AWS CLI
-	defaultAWSRegion = "eu-west-1"
-	// Regular expresion for extracting the InfrastructureID configured by `openshift-installer` from AWS Tags
-	infraIDRegexp = "kubernetes.io/cluster/.*-(.{5}?)$"
-	// Regular expresion for extracting the Cluster's Name configured by `openshift-installer` from AWS Tags
-	clusterNameRegexp = "kubernetes.io/cluster/(.*?)-.{5}$"
-
 	// Default codes for Unknown parameters
-	unknownAccountIDCode   = "Unknown Account ID"
-	unknownClusterNameCode = "NO_CLUSTER"
-	unknownConsoleLinkCode = "Unknown Console Link"
+	unknownAccountIDCode = "Unknown Account ID"
 )
 
 // AWSStocker object to make stock on AWS
 type AWSStocker struct {
-	region  string
 	Account *inventory.Account
 	logger  *zap.Logger
-	// AWS Session objects
-	apiSession *session.Session
+	conn    *cp.AWSConnection
 }
 
 // NewAWSStocker create and returns a pointer to a new AWSStocker instance
 func NewAWSStocker(account *inventory.Account, logger *zap.Logger) *AWSStocker {
-	st := AWSStocker{region: defaultAWSRegion, logger: logger}
-	st.Account = account
-
-	// Creating Session for the AWS API
-	if err := st.Connect(); err != nil {
-		st.logger.Error("Failed to initialize new session during AWSStocker creation", zap.Error(err))
-		return nil
-	}
-
-	accountID, err := getAWSAccountID(st.apiSession)
+	// Leaving the region empty forces to the AWSConnection to use the default region until a new one is configured
+	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", logger, cp.WithEC2(), cp.WithRoute53(), cp.WithSTS())
 	if err != nil {
-		st.logger.Error("Can't obtain AccountID", zap.Error(err))
+		logger.Error("Error creating a new AWSStocker", zap.Error(err))
 		return nil
 	}
 
-	st.Account.ID = accountID
+	// Getting AWS AccountID if it's empty
+	if account.ID == "" {
+		account.ID = conn.GetAccountID()
+	}
 
-	return &st
+	return &AWSStocker{
+		Account: account,
+		logger:  logger,
+		conn:    conn,
+	}
 }
 
 // Connect Initialices the AWS API and CostExplorer sessions and clients
 func (s *AWSStocker) Connect() error {
-	var err error
-	// Third argument (token) it's not used. For more info check docs: https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/credentials#NewStaticCredentials
-	creds := credentials.NewStaticCredentials(s.Account.GetUser(), s.Account.GetPassword(), "")
-	if creds == nil {
-		return fmt.Errorf("Cannot obtain AWS credentials for Account: %s\n", s.Account.ID)
-	}
-
-	// Preparing AWSConfig for new AWS API Session
-	awsConfig := aws.NewConfig().WithCredentials(creds).WithRegion(s.region)
-	if awsConfig == nil {
-		return fmt.Errorf("Cannot obtain AWS config for Account: %s\n", s.Account.ID)
-	}
-
-	// Creating Session for AWS API
-	s.apiSession, err = session.NewSession(awsConfig)
-	if err != nil {
-		s.logger.Error("Cannot Create new AWS client session", zap.Error(err))
-		return err
-	}
-
-	s.logger.Info("AWS Session created", zap.String("account_id", s.Account.Name))
-	return nil
+	return s.conn.Connect()
 }
 
 // MakeStock Implements the interface Stocker for triggering the entire process of making stock about a AWS account
 func (s *AWSStocker) MakeStock() error {
-	regions := s.getRegions()
+	regions, err := s.conn.EC2.GetRegionsList()
+	if err != nil {
+		return err
+	}
 
 	// TODO: Can we paralelize this?
 	for _, region := range regions {

--- a/internal/stocker/aws_stocker.go
+++ b/internal/stocker/aws_stocker.go
@@ -21,7 +21,7 @@ type AWSStocker struct {
 // NewAWSStocker create and returns a pointer to a new AWSStocker instance
 func NewAWSStocker(account *inventory.Account, logger *zap.Logger) *AWSStocker {
 	// Leaving the region empty forces to the AWSConnection to use the default region until a new one is configured
-	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", logger, cp.WithEC2(), cp.WithRoute53(), cp.WithSTS())
+	conn, err := cp.NewAWSConnection(account.GetUser(), account.GetPassword(), "", cp.WithEC2(), cp.WithRoute53(), cp.WithSTS())
 	if err != nil {
 		logger.Error("Error creating a new AWSStocker", zap.Error(err))
 		return nil

--- a/internal/stocker/aws_stocker_ec2.go
+++ b/internal/stocker/aws_stocker_ec2.go
@@ -2,55 +2,21 @@ package stocker
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"go.uber.org/zap"
 )
 
 // TODO: doc
-func (s AWSStocker) getRegions() []string {
-	ec2Client := ec2.New(s.apiSession)
-
-	regions, err := ec2Client.DescribeRegions(&ec2.DescribeRegionsInput{})
-	if err != nil {
-		s.logger.Warn("Failed to retrieve AWS regions", zap.String("reason", err.Error()))
-		return nil
-	}
-
-	result := make([]string, 0)
-
-	for _, region := range regions.Regions {
-		result = append(result, *region.RegionName)
-	}
-
-	return result
-}
-
-// parseInfraID parses a Tag key to obtain the InfraID
-func parseInfraID(key string) string {
-	re := regexp.MustCompile(infraIDRegexp)
-	res := re.FindAllStringSubmatch(key, 1)
-
-	// if there are no results, return empty string, if there are, return first match
-	if len(res) <= 0 {
-		return ""
-	}
-	return res[0][1]
-}
-
-// TODO: doc
 func (s *AWSStocker) processRegion(region string) error {
-	s.region = region
-	// TODO: Add error check
-	s.Connect()
-	ec2Client := ec2.New(s.apiSession)
-	s.logger.Info("Scraping region", zap.String("region", s.region), zap.String("account", s.Account.Name))
+	if err := s.conn.SetRegion(region); err != nil {
+		return err
+	}
+	s.logger.Info("Scraping region", zap.String("region", s.conn.GetRegion()), zap.String("account", s.Account.Name))
 
-	instances, err := getInstances(ec2Client)
+	instances, err := s.conn.EC2.GetInstances()
 	if err != nil {
-		return fmt.Errorf("couldn't retrieve EC2 instances in region %s: %w", s.region, err)
+		return fmt.Errorf("couldn't retrieve EC2 instances in region %s: %w", s.conn.GetRegion(), err)
 	}
 
 	// convert instances from ec2 to inventory.Instance
@@ -59,69 +25,40 @@ func (s *AWSStocker) processRegion(region string) error {
 	return nil
 }
 
-// parseClusterName parses a Tag key to obtain the clusterName
-func parseClusterName(key string) string {
-	re := regexp.MustCompile(clusterNameRegexp)
-	res := re.FindAllStringSubmatch(key, 1)
-
-	// if there are no results, return empty string, if there are, return first match
-	if len(res) <= 0 {
-		return unknownClusterNameCode
-	}
-	return res[0][1]
-}
-
 // processInstances gets every AWS EC2 instance, parse it, a
-func (s *AWSStocker) processInstances(instances *ec2.DescribeInstancesOutput) {
-	for _, reservation := range instances.Reservations {
-		for _, instance := range reservation.Instances {
-			// Instance properties
-			var name string
-			var infraID string
-			var clusterName string
-			var owner string
+func (s *AWSStocker) processInstances(instances []inventory.Instance) {
+	// Getting Instances metadata
+	for i, instance := range instances {
 
-			// Getting Instance properties
-			id := *instance.InstanceId
-			availabilityZone := *instance.Placement.AvailabilityZone
-			region := availabilityZone[:len(availabilityZone)-1]
-			instanceType := *instance.InstanceType
-			provider := inventory.AWSProvider
-			status := inventory.AsInstanceStatus(*instance.State.Name)
-			tags := instance.Tags
-			creationTimestamp := *instance.LaunchTime
-
-			// Getting Instance's metadata
-			name = getInstanceNameFromTags(*instance)
-			clusterName = getClusterNameFromTags(*instance)
-			infraID = getInfraIDFromTags(*instance)
-			owner = getOwnerFromTags(*instance)
-
-			// Generating ClusterID for this instance based on its properties
-			clusterID, err := inventory.GenerateClusterID(clusterName, infraID, s.Account.Name)
-			if err != nil {
-				s.logger.Error("Error obtainning ClusterID for a new instance add", zap.Error(err))
-			}
-
-			// Checking if the cluster of the instance already exists on the inventory
-			if !s.Account.IsClusterOnAccount(clusterID) {
-				cluster := inventory.NewCluster(clusterName, infraID, provider, region, s.Account.Name, unknownConsoleLinkCode, owner)
-				s.Account.AddCluster(cluster)
-			}
-
-			// Adding the instance to the Cluster
-			newInstance := inventory.NewInstance(id, name, provider, instanceType, availabilityZone, status, clusterID, inventory.ConvertEC2TagtoTag(tags, id), creationTimestamp)
-			s.Account.Clusters[clusterID].AddInstance(*newInstance)
+		// Generating ClusterID for this instance based on its properties
+		clusterName := inventory.GetClusterNameFromTags(instance.Tags)
+		infraID := inventory.GetInfraIDFromTags(instance.Tags)
+		clusterID, err := inventory.GenerateClusterID(
+			clusterName,
+			infraID,
+			s.Account.Name,
+		)
+		if err != nil {
+			s.logger.Error("Error obtainning ClusterID for a new instance add", zap.Error(err))
 		}
-	}
-}
 
-// getInstances TODO
-func getInstances(client *ec2.EC2) (*ec2.DescribeInstancesOutput, error) {
-	result, err := client.DescribeInstances(&ec2.DescribeInstancesInput{})
-	if err != nil {
-		return nil, err
-	}
+		instances[i].ClusterID = clusterID
 
-	return result, err
+		// Checking if the cluster of the instance already exists on the inventory
+		if !s.Account.IsClusterOnAccount(clusterID) {
+			cluster := inventory.NewCluster(
+				clusterName,
+				infraID,
+				inventory.AWSProvider,
+				s.conn.GetRegion(),
+				s.Account.Name,
+				unknownConsoleLinkCode,
+				inventory.GetOwnerFromTags(instances[i].Tags),
+			)
+			s.Account.AddCluster(cluster)
+		}
+
+		// Adding the instance to the Cluster
+		s.Account.Clusters[clusterID].AddInstance(instances[i])
+	}
 }

--- a/internal/stocker/aws_stocker_route53.go
+++ b/internal/stocker/aws_stocker_route53.go
@@ -1,7 +1,6 @@
 package stocker
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
@@ -14,46 +13,14 @@ const (
 	// consoleProtocolPrefix defines the "HTTP" protocol header
 	consoleProtocolPrefix = "https://"
 	// consoleLinkPrefix is the pre-defined hostname for the Openshift Console
-	consoleLinkPrefix = "console-openshift-console.apps."
+	consoleLinkPrefix      = "console-openshift-console.apps."
+	unknownConsoleLinkCode = "UNKNOWN-CONSOLE"
 )
 
 // generateConsoleLink attaches the consoleLinkPrefix to the baseDomain specified by args
 func generateConsoleLink(baseDomain string) *string {
 	consoleLink := consoleProtocolPrefix + consoleLinkPrefix + baseDomain
 	return &consoleLink
-}
-
-// getRoute53HostedZones get a list of every Hosted Zone on the Route53 service
-func getRoute53HostedZones(client *route53.Route53) ([]*route53.HostedZone, error) {
-	input := route53.ListHostedZonesByNameInput{}
-	result, err := client.ListHostedZonesByName(&input)
-	if err != nil {
-		return nil, err
-	}
-	return result.HostedZones, nil
-}
-
-// getHostedZoneRecords returns every record of a given HostedZone
-func getHostedZoneRecords(r53client *route53.Route53, hostedZoneID string) ([]*route53.ResourceRecordSet, error) {
-	// Define input for ListResourceRecordSets
-	input := &route53.ListResourceRecordSetsInput{
-		HostedZoneId: aws.String(hostedZoneID),
-	}
-
-	var records []*route53.ResourceRecordSet
-
-	// API Call for getting DNS records
-	err := r53client.ListResourceRecordSetsPages(input, func(page *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
-		records = append(records, page.ResourceRecordSets...)
-		return !lastPage // Continue if there are more record pages
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("Error getting the DNS registries: %v", err)
-	}
-
-	return records, nil
-
 }
 
 // searchConsoleURLinDNSRecords looks for the console link on the record list
@@ -66,9 +33,9 @@ func searchConsoleURLinDNSRecords(records []*route53.ResourceRecordSet, cluster 
 	return nil
 }
 
-// getConsoleLinkOfCluster returns the corresponding ConsoleLink for a given cluster
-func getConsoleLinkOfCluster(client *route53.Route53, cluster *inventory.Cluster, hostedZone *route53.HostedZone) string {
-	records, err := getHostedZoneRecords(client, *hostedZone.Id)
+// GetConsoleLinkOfCluster returns the corresponding ConsoleLink for a given cluster
+func (s *AWSStocker) getConsoleLinkOfCluster(cluster *inventory.Cluster, hostedZone *route53.HostedZone) string {
+	records, err := s.conn.Route53.GetHostedZoneRecords(*hostedZone.Id)
 	if err != nil {
 		return unknownConsoleLinkCode
 	}
@@ -81,29 +48,9 @@ func getConsoleLinkOfCluster(client *route53.Route53, cluster *inventory.Cluster
 	return unknownConsoleLinkCode
 }
 
-// checkIfHostedZoneBelongsToCluster returns true or false if the hosted zone is associated to a cluster Ingress (routers)
-func checkIfHostedZoneBelongsToCluster(client *route53.Route53, cluster *inventory.Cluster, hostedZone *route53.HostedZone) bool {
-	hztype := route53.TagResourceTypeHostedzone
-	output, err := client.ListTagsForResource(&route53.ListTagsForResourceInput{
-		ResourceType: &hztype,
-		ResourceId:   aws.String(*hostedZone.Id),
-	})
-	if err != nil {
-		return false
-	}
-
-	for _, tag := range output.ResourceTagSet.Tags {
-		if strings.Contains(*(tag.Key), cluster.Name) {
-			return true
-		}
-	}
-	return false
-}
-
 // FindOpenshiftConsoleURLs iterates every Cluster and every Route53 HostedZone for looking for the corresponding URLs for the OCP console
 func (s *AWSStocker) FindOpenshiftConsoleURLs() error {
-	r53client := route53.New(s.apiSession)
-	hostedZones, err := getRoute53HostedZones(r53client)
+	hostedZones, err := s.conn.Route53.GetRoute53HostedZones()
 	if err != nil {
 		return err
 	}
@@ -111,9 +58,9 @@ func (s *AWSStocker) FindOpenshiftConsoleURLs() error {
 	for i, cluster := range s.Account.Clusters {
 		for _, hostedZone := range hostedZones {
 			// Checking if the current hosted zone belongs to the current cluster
-			if checkIfHostedZoneBelongsToCluster(r53client, cluster, hostedZone) {
+			if s.conn.Route53.CheckIfHostedZoneBelongsToCluster(cluster, hostedZone) {
 				s.logger.Debug("Found Hosted Zone for Cluster", zap.String("hosted_zone_id", *hostedZone.Id), zap.String("cluster_id", cluster.ID))
-				s.Account.Clusters[i].ConsoleLink = getConsoleLinkOfCluster(r53client, cluster, hostedZone)
+				s.Account.Clusters[i].ConsoleLink = s.getConsoleLinkOfCluster(cluster, hostedZone)
 			}
 		}
 	}

--- a/internal/stocker/aws_stocker_tags.go
+++ b/internal/stocker/aws_stocker_tags.go
@@ -1,15 +1,9 @@
 package stocker
 
-import (
-	"strings"
-
-	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
-	"github.com/aws/aws-sdk-go/service/ec2"
-)
-
 // getInfraIDFromTags search and return the infrastructure associted to the instance,
 // if it belongs to a cluster. Empty string is returned if the
 // instance doesn't belong to any cluster
+/*
 func getInfraIDFromTags(instance ec2.Instance) string {
 	var tags []ec2.Tag
 	tags = *(lookForTagByValue("owned", instance.Tags))
@@ -67,14 +61,4 @@ func lookForTagByValue(value string, tags []*ec2.Tag) *[]ec2.Tag {
 	}
 	return &resultTags
 }
-
-// lookForTagByKey returns an array of ec2.Tag with every tag found with the specified key
-func lookForTagByKey(key string, tags []*ec2.Tag) *[]ec2.Tag {
-	var resultTags []ec2.Tag
-	for _, tag := range tags {
-		if *tag.Key == key {
-			resultTags = append(resultTags, *tag)
-		}
-	}
-	return &resultTags
-}
+*/


### PR DESCRIPTION
First approach for separating the cloud providers code from scanner and agent. This will allow us to use same library for interacting with public cloud providers, separate the cloud provider code from Cluster-iq code, and reuse it in the Agent and Scanner 