### PR TITLE
bug: avoid redundant inventory refresh on non-relevant endpoints

### DIFF
--- a/cmd/api/router.go
+++ b/cmd/api/router.go
@@ -27,6 +27,7 @@ func (r *Router) SetupRoutes() {
 	r.setupAccountsRoutes(baseGroup)
 	r.setupEventsRoutes(baseGroup)
 	r.setupOverviewRoutes(baseGroup)
+	r.setupInventoryRoutes(baseGroup)
 }
 
 func (r *Router) setupHealthcheckRoutes(baseGroup *gin.RouterGroup) {
@@ -55,24 +56,22 @@ func (r *Router) setupExpensesRoutes(baseGroup *gin.RouterGroup) {
 
 func (r *Router) setupInstancesRoutes(baseGroup *gin.RouterGroup) {
 	instancesGroup := baseGroup.Group("/instances")
-	instancesGroup.Use(r.api.HandlerRefreshInventory)
 	instancesGroup.GET("", r.api.HandlerGetInstances)
 	instancesGroup.GET("/expense_update", r.api.HandlerGetInstancesForBillingUpdate)
 	instancesGroup.GET("/:instance_id", r.api.HandlerGetInstanceByID)
-	instancesGroup.POST("", r.api.HandlerPostInstance)
+	instancesGroup.POST("", r.api.HandlerPostInstance, r.api.HandlerRefreshInventory)
 	instancesGroup.DELETE("/:instance_id", r.api.HandlerDeleteInstance)
 	instancesGroup.PATCH("/:instance_id", r.api.HandlerPatchInstance)
 }
 
 func (r *Router) setupClustersRoutes(baseGroup *gin.RouterGroup) {
 	clustersGroup := baseGroup.Group("/clusters")
-	clustersGroup.Use(r.api.HandlerRefreshInventory)
 	clustersGroup.GET("", r.api.HandlerGetClusters)
 	clustersGroup.GET("/:cluster_id", r.api.HandlerGetClustersByID)
 	clustersGroup.GET("/:cluster_id/instances", r.api.HandlerGetInstancesOnCluster)
 	clustersGroup.GET("/:cluster_id/tags", r.api.HandlerGetClusterTags)
 	clustersGroup.GET("/:cluster_id/events", r.api.HandlerGetClusterEvents)
-	clustersGroup.POST("", r.api.HandlerPostCluster)
+	clustersGroup.POST("", r.api.HandlerPostCluster, r.api.HandlerRefreshInventory)
 	clustersGroup.POST("/:cluster_id/power_on", r.api.HandlerPowerOnCluster)
 	clustersGroup.POST("/:cluster_id/power_off", r.api.HandlerPowerOffCluster)
 	clustersGroup.DELETE("/:cluster_id", r.api.HandlerDeleteCluster)
@@ -92,6 +91,11 @@ func (r *Router) setupAccountsRoutes(baseGroup *gin.RouterGroup) {
 func (r *Router) setupOverviewRoutes(baseGroup *gin.RouterGroup) {
 	overviewGroup := baseGroup.Group("/overview")
 	overviewGroup.GET("", r.api.HandlerGetInventoryOverview)
+}
+
+func (r *Router) setupInventoryRoutes(baseGroup *gin.RouterGroup) {
+	inventoryGroup := baseGroup.Group("/inventory")
+	inventoryGroup.POST("/refresh", r.api.HandlerRefreshInventory)
 }
 
 func (r *Router) setupEventsRoutes(baseGroup *gin.RouterGroup) {

--- a/internal/sql_client/sql_client.go
+++ b/internal/sql_client/sql_client.go
@@ -929,14 +929,30 @@ func (a SQLClient) DeleteAccount(accountName string) error {
 // Returns:
 // - An error if any update query fails.
 func (a SQLClient) RefreshInventory() error {
-	var result sql.Result
+	tx, err := a.db.Beginx()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if tx != nil {
+			if rbErr := tx.Rollback(); rbErr != nil && rbErr != sql.ErrTxDone {
+				a.logger.Error("Error during transaction rollback", zap.Error(rbErr))
+			}
+		}
+	}()
 
-	if result = a.db.MustExec(UpdateTerminatedInstancesQuery); result == nil {
-		return fmt.Errorf("cannot refresh terminated instances")
+	_, err = tx.Exec(UpdateTerminatedInstancesQuery)
+	if err != nil {
+		return fmt.Errorf("failed to refresh terminated instances: %w", err)
 	}
 
-	if result = a.db.MustExec(UpdateTerminatedClustersQuery); result == nil {
-		return fmt.Errorf("cannot refresh terminated clusters")
+	_, err = tx.Exec(UpdateTerminatedClustersQuery)
+	if err != nil {
+		return fmt.Errorf("failed to refresh terminated clusters: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR scopes the `RefreshInventory` logic to only the relevant POST endpoints.
Previously, the middleware triggered inventory refresh across all endpoints, leading to unnecessary calls to the DB.

After this change:

- `RefreshInventory` is invoked only for specific POST requests that require it.
- This reduces overhead and minimizes risk of deadlocks in unrelated flows.