### PR TITLE
feat: added last scan date to the Overview API

### DIFF
--- a/cmd/api/handlers.go
+++ b/cmd/api/handlers.go
@@ -1201,7 +1201,6 @@ func (a APIServer) getInventoryOverview() (models.OverviewSummary, error) {
 	if err != nil {
 		return models.OverviewSummary{}, fmt.Errorf("failed to get clusters overview: %w", err)
 	}
-
 	overview.Clusters = clusters
 
 	// Get instances summary
@@ -1216,8 +1215,14 @@ func (a APIServer) getInventoryOverview() (models.OverviewSummary, error) {
 	if err != nil {
 		return models.OverviewSummary{}, fmt.Errorf("failed to get providers overview: %w", err)
 	}
-
 	overview.Providers = providers
+
+	// Get scanner last scan timestamp
+	scannerLastScan, err := a.sql.GetScannerLastScanTimestamp()
+	if err != nil {
+		return models.OverviewSummary{}, fmt.Errorf("failed to get scanner last scan timestamp: %w", err)
+	}
+	overview.Scanner = models.Scanner{LastScanTimestamp: scannerLastScan}
 
 	return overview, nil
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -98,6 +98,11 @@ type OverviewSummary struct {
 	Clusters  ClustersSummary  `json:"clusters"`
 	Instances InstancesSummary `json:"instances"`
 	Providers ProvidersSummary `json:"providers"`
+	Scanner   Scanner          `json:"scanner"`
+}
+
+type Scanner struct {
+	LastScanTimestamp *time.Time `json:"last_scan_timestamp"`
 }
 
 type ClustersSummary struct {

--- a/internal/sql_client/sql_client.go
+++ b/internal/sql_client/sql_client.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/RHEcosystemAppEng/cluster-iq/internal/actions"
 	"github.com/RHEcosystemAppEng/cluster-iq/internal/events"
@@ -1029,6 +1030,18 @@ func (a SQLClient) CheckStatusValue(status string) (bool, error) {
 		return false, err
 	}
 	return exists, nil
+}
+
+// GetScannerLastScanTimestamp returns the latest scan timestamp across all accounts
+func (a SQLClient) GetScannerLastScanTimestamp() (*time.Time, error) {
+	var lastScanTimestamp sql.NullTime
+	if err := a.db.Get(&lastScanTimestamp, SelectScannerLastScanTimestamp); err != nil {
+		return nil, err
+	}
+	if lastScanTimestamp.Valid {
+		return &lastScanTimestamp.Time, nil
+	}
+	return nil, nil
 }
 
 // joinInstancesTags maps an array of InstanceDB objects into a slice of inventory.Instance objects.

--- a/internal/sql_client/sql_queries.go
+++ b/internal/sql_client/sql_queries.go
@@ -542,4 +542,6 @@ const (
 
 	// CheckStatusQuery checks if the requested status exists on the DB
 	CheckStatusQuery = `SELECT EXISTS (SELECT 1 FROM status WHERE value=$1)`
+	// SelectScannerLastScanTimestamp returns the latest scan timestamp across all accounts
+	SelectScannerLastScanTimestamp = `SELECT MAX(last_scan_timestamp) as last_scan_timestamp FROM accounts;`
 )


### PR DESCRIPTION
Add a `scanner` field with `last_scan_timestamp` to the `Overview` API response
Closes #199 