### PR TITLE
feat(ci): migrate linters and update all workflows

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -23,7 +23,7 @@ jobs:
       LATEST_TAG: ${{ steps.vars.outputs.LATEST_TAG }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Needed for getting Git Tags
 
@@ -70,7 +70,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to Quay.io
         run: |
@@ -118,7 +118,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to Quay.io
         run: |
@@ -166,7 +166,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to Quay.io
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,19 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Extract Go Version from go.mod
-        id: go_version
-        run: echo "GO_VERSION=$(awk '/^go /{print $2}' go.mod)" >> $GITHUB_ENV
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Install podman and podman-compose
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,18 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Extract Go Version from go.mod
-        id: go_version
-        run: echo "GO_VERSION=$(awk '/^go /{print $2}' go.mod)" >> $GITHUB_ENV
-
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run Go Unit Tests
         run: |

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -3,37 +3,31 @@ name: Pull Request Validation
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   golangci:
-    name: Go code format check
+    name: Go Linter
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Extract Go Version from go.mod
-        id: go_version
-        run: echo "GO_VERSION=$(awk '/^go /{print $2}' go.mod)" >> $GITHUB_ENV
-
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
-      - name: Check formatting
-        run: |
-          if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then
-            echo "The following files are not properly formatted:"
-            gofmt -l .
-            exit 1
-          fi
-
-      - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v6
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.5
+          only-new-issues: true
+          args: --whole-files
+          version: v2.1
 
   call-unit-tests:
     name: Go Unit tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,19 @@
+version: "2"
+run:
+  relative-path-mode: gomod
+  modules-download-mode: readonly
+  tests: false
 linters:
-  disable-all: true
+  default: none
   enable:
     - containedctx
     - copyloopvar
     - cyclop
     - errcheck
     - exhaustive
-    - gci
     - gochecksumtype
     - goconst
     - gocritic
-    - gofmt
-    - gosimple
     - govet
     - inamedparam
     - ineffassign
@@ -21,27 +23,34 @@ linters:
     - revive
     - sqlclosecheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - internal/inventory/tag_test.go
+      - .*.pb.go
+      - generated/agent
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # fix only newly added issue
-  # https://golangci-lint.run/welcome/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues
-  new-from-rev: HEAD~1
-  # OR https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues
   uniq-by-line: true
-  exclude-dirs:
-    - generated/agent
-  exclude-files:
-  # intentionally until we fix the import
-    - internal/inventory/tag_test.go
-    - .*.pb.go
-run:
-  timeout: "20m"
-  relative-path-mode: gomod
-  # intentionally until we add proper tests
-  tests: false
-  # fails when any changes to go.mod are needed. 
-  # this setting is most useful in a continuous integration and testing system
-  modules-download-mode: readonly
+formatters:
+  enable:
+    - gci
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - internal/inventory/tag_test.go
+      - .*.pb.go
+      - generated/agent
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,17 @@ go-integration-tests: go-setup-tests
 go-tests: ## Runs every test
 go-tests: go-unit-tests go-integration-tests
 
-go-linter: ## Runs go linter tools
+lint: ## Runs go linter tools against the whole project
 	@$(GO_LINTER) run
+
+lint-staged: ## Runs go linter tools against staged files
+	@echo "### [Running Linter against staged files] ###"
+	@STAGED_FILES=$$(git diff --name-only --staged -- '*.go' ':(exclude)*.pb.go'); \
+	if [ -z "$$STAGED_FILES" ]; then \
+		echo "No staged Go files to lint."; \
+	else \
+		$(GO_LINTER) run --new-from-patch=<(git diff --staged -- '*.go' ':(exclude)*.pb.go') --whole-files; \
+	fi
 
 go-fmt: ## Runs go formatting tools
 	@WRONG_LINES="$$($(GO_FMT) -l . | wc -l)"; \


### PR DESCRIPTION
This PR updates the CI linting process and associated workflows.
Changes:

- Updated `.golangci.yml`: The linter configuration has been updated and migrated to version v2. Settings specific to the execution environment (like new-from-rev) have been removed, so the file now only defines what linters to run.

- Updated GitHub Workflows: All workflows now use the latest major versions of `actions/checkout (v5)`, `actions/setup-go (v6)`, and `golangci-lint-action (v8)`. The Go version is now set consistently by reading from `go.mod`.

- Improved Pull Request Linting: The validation workflow now lints only the files changed in a PR. It checks the entire file, not just the changed lines, to catch related errors (like unused imports).

New Makefile Commands:
Added `make lint-staged` to run the linter locally on staged files before committing.