### PR TITLE
bug: add console_link field to clusters_full_view

### DIFF
--- a/db/sql/init.sql
+++ b/db/sql/init.sql
@@ -337,6 +337,7 @@ SELECT
   c.region,
   a.account_id,
   a.account_name,
+  c.console_link,
   c.last_scan_ts,
   c.created_at,
   c.age,


### PR DESCRIPTION
How to recreate the view
Run under a user who has permissions to the database

```sql
DROP VIEW IF EXISTS clusters_full_view CASCADE;
CREATE VIEW clusters_full_view AS
SELECT
  c.cluster_id,
  c.cluster_name,
  c.infra_id,
  c.provider,
  c.status,
  c.region,
  a.account_id,
  a.account_name,
  c.console_link,
  c.last_scan_ts,
  c.created_at,
  c.age,
  c.owner,
  COALESCE(cc.instance_count, 0)                                       AS instance_count,
  COALESCE(ac.total_cost, 0)                                           AS total_cost,
  COALESCE(ac.last_15_days_cost, 0)                                    AS last_15_days_cost,
  COALESCE(ac.last_month_cost, 0)                                      AS last_month_cost,
  COALESCE(ac.current_month_so_far_cost, 0)                            AS current_month_so_far_cost
FROM clusters c
LEFT JOIN accounts a ON c.account_id = a.id
LEFT JOIN clusters_with_instance_count cc ON cc.cluster_id = c.id
LEFT JOIN clusters_with_costs         ac ON ac.id = c.id;

DROP MATERIALIZED VIEW IF EXISTS m_clusters_full_view;
CREATE MATERIALIZED VIEW m_clusters_full_view AS SELECT * FROM clusters_full_view;
```