### PR TITLE
fix: enable pg_cron in PostgreSQL statefulset

### DIFF
--- a/db/sql/cron.sql
+++ b/db/sql/cron.sql
@@ -1,6 +1,7 @@
 \c postgres
 
 -- pg_cron task for updating the 'Terminated' elements in the inventory every 6 hours
+CREATE EXTENSION IF NOT EXISTS pg_cron;
 SELECT cron.schedule_in_database(
   'check_terminated_inventory',
   '0 */6 * * *',

--- a/deployments/helm/cluster-iq/templates/database/configmap-init.yaml
+++ b/deployments/helm/cluster-iq/templates/database/configmap-init.yaml
@@ -8,6 +8,9 @@ metadata:
 immutable: false
 data:
   cron.sql: |
+    \c postgres
+    CREATE EXTENSION IF NOT EXISTS pg_cron;
+
     -- pg_cron task for updating the 'Terminated' elements in the inventory every 6 hours
     SELECT cron.schedule_in_database(
       'check_terminated_inventory',

--- a/deployments/helm/cluster-iq/templates/database/statefulset.yaml
+++ b/deployments/helm/cluster-iq/templates/database/statefulset.yaml
@@ -49,6 +49,11 @@ spec:
           envFrom:
           - secretRef:
               name: postgresql
+          env:
+          - name: POSTGRESQL_LIBRARIES
+            value: "pg_cron"
+          - name: POSTGRESQL_EXTENSIONS
+            value: "pg_cron"
           securityContext:
             {{- toYaml .Values.database.securityContext | nindent 12 }}
           image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
@r2dedios DON'T MERGE! Discuss the destination branch first

Fix `pg_cron` initialization by adding required env vars (`POSTGRESQL_LIBRARIES`, `POSTGRESQL_EXTENSIONS`) to PostgreSQL StatefulSet
Updated `cron.sql` and Helm ConfigMap with `CREATE EXTENSION` command.