### PR TITLE
chore: remove pagination size limit

### DIFF
--- a/internal/models/dto/pagination.go
+++ b/internal/models/dto/pagination.go
@@ -4,5 +4,5 @@ package dto
 // allowing clients to specify page number and page size.
 type PaginationRequest struct {
 	Page     int `form:"page,default=1" binding:"gte=1"`
-	PageSize int `form:"page_size,default=10" binding:"gte=1,lte=100"`
+	PageSize int `form:"page_size,default=10" binding:"gte=1"`
 } // @name PaginationRequest


### PR DESCRIPTION
This change removes the hardcoded upper limit on page size, allowing clients to fetch larger datasets in a single request, since we use client-side filtering