### PR TITLE
fix: initialize repository slices to return empty array instead of null

### DIFF
--- a/internal/repositories/account_repository.go
+++ b/internal/repositories/account_repository.go
@@ -69,7 +69,7 @@ func NewAccountRepository(db *dbclient.DBClient) AccountRepository {
 // - A slice of inventory.Account objects.
 // - An error if the query fails.
 func (r *accountRepositoryImpl) ListAccounts(ctx context.Context, opts models.ListOptions) ([]db.AccountDBResponse, int, error) {
-	var accounts []db.AccountDBResponse
+	accounts := []db.AccountDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &accounts, SelectAccountsMView, opts, "account_id", "*"); err != nil {
 		return accounts, 0, fmt.Errorf("failed to list accounts: %w", err)
@@ -130,7 +130,7 @@ func (r *accountRepositoryImpl) GetAccountByID(ctx context.Context, accountID st
 // - A slice of inventory.Account objects (usually containing one element).
 // - An error if the query fails.
 func (r *accountRepositoryImpl) GetAccountClustersByID(ctx context.Context, accountID string) ([]db.ClusterDBResponse, error) {
-	var clusters []db.ClusterDBResponse
+	clusters := []db.ClusterDBResponse{}
 
 	opts := models.ListOptions{
 		PageSize: 0,
@@ -157,7 +157,7 @@ func (r *accountRepositoryImpl) GetAccountClustersByID(ctx context.Context, acco
 // - A slice of inventory.Instance objects.
 // - An error if the query fails.
 func (r *accountRepositoryImpl) GetExpenseUpdateInstances(ctx context.Context, accountID string) ([]db.InstanceDBResponse, error) {
-	var instances []db.InstanceDBResponse
+	instances := []db.InstanceDBResponse{}
 
 	opts := models.ListOptions{
 		PageSize: 0,

--- a/internal/repositories/action_repository.go
+++ b/internal/repositories/action_repository.go
@@ -126,7 +126,7 @@ func NewActionRepository(db *dbclient.DBClient) ActionRepository {
 //   - An array of actions.Action with the scheduled actions declared on the DB
 //   - An error if the query fails
 func (r *actionRepositoryImpl) List(ctx context.Context, opts models.ListOptions) ([]db.ActionDBResponse, int, error) {
-	var schedule []db.ActionDBResponse
+	schedule := []db.ActionDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &schedule, SelectScheduleFullView, opts, "id", "*"); err != nil {
 		return schedule, 0, fmt.Errorf("failed to list schedule: %w", err)

--- a/internal/repositories/cluster_repository.go
+++ b/internal/repositories/cluster_repository.go
@@ -93,7 +93,7 @@ func NewClusterRepository(db *dbclient.DBClient) ClusterRepository {
 // - A slice of inventory.Cluster objects.
 // - An error if the query fails.
 func (r *clusterRepositoryImpl) ListClusters(ctx context.Context, opts models.ListOptions) ([]db.ClusterDBResponse, int, error) {
-	var clusters []db.ClusterDBResponse
+	clusters := []db.ClusterDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &clusters, SelectClustersFullMView, opts, "cluster_id", "*"); err != nil {
 		return clusters, 0, fmt.Errorf("failed to list clusters: %w", err)
@@ -188,7 +188,7 @@ func (r *clusterRepositoryImpl) GetClusterRegion(ctx context.Context, clusterID 
 // - A slice of inventory.Tag objects representing the cluster's tags.
 // - An error if the query fails.
 func (r *clusterRepositoryImpl) GetClusterTags(ctx context.Context, clusterID string) ([]db.TagDBResponse, error) {
-	var result []db.TagDBResponse
+	result := []db.TagDBResponse{}
 
 	opts := models.ListOptions{
 		PageSize: 0,
@@ -239,7 +239,7 @@ func (r *clusterRepositoryImpl) GetClustersOnAccount(ctx context.Context, accoun
 // - A slice of inventory.Instance objects representing the instances in the cluster.
 // - An error if the query fails.
 func (r *clusterRepositoryImpl) GetInstancesOnCluster(ctx context.Context, clusterID string) ([]db.InstanceDBResponse, error) {
-	var instances []db.InstanceDBResponse
+	instances := []db.InstanceDBResponse{}
 
 	opts := models.ListOptions{
 		PageSize: 0,

--- a/internal/repositories/event_repository.go
+++ b/internal/repositories/event_repository.go
@@ -70,7 +70,7 @@ func NewEventRepository(db *dbclient.DBClient) EventRepository {
 
 // ListSystemEvents retrieves system-wide events with extended metadata.
 func (r *eventRepositoryImpl) ListSystemEvents(ctx context.Context, opts models.ListOptions) ([]db.SystemEventDBResponse, int, error) {
-	var events []db.SystemEventDBResponse
+	events := []db.SystemEventDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &events, SelectSystemEventsView, opts, "event_timestamp", "*"); err != nil {
 		return events, 0, fmt.Errorf("failed to list events: %w", err)
@@ -81,7 +81,7 @@ func (r *eventRepositoryImpl) ListSystemEvents(ctx context.Context, opts models.
 
 // ListClusterEvents retrieves events for a specific resource (like a cluster).
 func (r *eventRepositoryImpl) ListClusterEvents(ctx context.Context, opts models.ListOptions) ([]db.ClusterEventDBResponse, int, error) {
-	var events []db.ClusterEventDBResponse
+	events := []db.ClusterEventDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &events, SelectClusterEventsView, opts, "event_timestamp", "*"); err != nil {
 		return events, 0, fmt.Errorf("failed to list cluster events: %w", err)

--- a/internal/repositories/expense_repository.go
+++ b/internal/repositories/expense_repository.go
@@ -53,7 +53,7 @@ func NewExpenseRepository(db *dbclient.DBClient) ExpenseRepository {
 // - A slice of inventory.Expense objects.
 // - An error if the query fails.
 func (r *expenseRepositoryImpl) ListExpenses(ctx context.Context, opts models.ListOptions) ([]db.ExpenseDBResponse, int, error) {
-	var expenses []db.ExpenseDBResponse
+	expenses := []db.ExpenseDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &expenses, ExpensesTable, opts, "date", "*"); err != nil {
 		return expenses, 0, fmt.Errorf("failed to list expenses: %w", err)

--- a/internal/repositories/instance_repository.go
+++ b/internal/repositories/instance_repository.go
@@ -97,7 +97,7 @@ func NewInstanceRepository(db *dbclient.DBClient) InstanceRepository {
 // - A slice of inventory.Instance objects.
 // - An error if the query fails.
 func (r *instanceRepositoryImpl) ListInstances(ctx context.Context, opts models.ListOptions) ([]db.InstanceDBResponse, int, error) {
-	var instances []db.InstanceDBResponse
+	instances := []db.InstanceDBResponse{}
 
 	if err := r.db.SelectWithContext(ctx, &instances, SelectInstancesFullMView, opts, "instance_id", "*"); err != nil {
 		return instances, 0, fmt.Errorf("failed to list instances: %w", err)
@@ -162,7 +162,7 @@ func (r *instanceRepositoryImpl) CreateInstances(ctx context.Context, instances 
 		return err
 	}
 
-	var newTags []inventory.Tag
+	newTags := []inventory.Tag{}
 	for _, instance := range instances {
 		for _, tag := range instance.Tags {
 			tag.InstanceID = instance.InstanceID


### PR DESCRIPTION
Explicitly initialize slices as empty `[]T{}` in repository methods.
This ensures API endpoints return `[]` JSON instead of `null` when no data is found, preventing frontend iterator errors.

Per [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments#declaring-empty-slices):
> "a nil slice encodes to null, while []string{} encodes to the JSON array []"
