### PR TITLE
fix: resolve logic bug causing skipped instances in AWS stocker

### DIFF
--- a/internal/stocker/aws_stocker_ec2.go
+++ b/internal/stocker/aws_stocker_ec2.go
@@ -35,6 +35,7 @@ func (s *AWSStocker) processInstances(instances []inventory.Instance) {
 		// Generating ClusterID for this instance based on its properties
 		clusterName := inventory.GetClusterNameFromTags(instance.Tags)
 		infraID := inventory.GetInfraIDFromTags(instance.Tags)
+
 		if s.skipNoOpenShiftInstances && clusterName == inventory.UnknownClusterNameCode {
 			s.logger.Debug("Skipping instance because it's not associated to any cluster",
 				zap.String("account_id", s.Account.AccountID),
@@ -61,14 +62,14 @@ func (s *AWSStocker) processInstances(instances []inventory.Instance) {
 			if !s.Account.IsClusterInAccount(cluster.ClusterID) {
 				_ = s.Account.AddCluster(cluster)
 			}
+		}
 
-			if err := s.Account.Clusters[clusterID].AddInstance(&instance); err != nil {
-				s.logger.Error("error adding instance to cluster during instance processing",
-					zap.String("account_id", s.Account.AccountID),
-					zap.String("cluster_id", clusterID),
-					zap.String("instance_id", instance.InstanceID),
-					zap.Error(err))
-			}
+		if err := s.Account.Clusters[clusterID].AddInstance(&instance); err != nil {
+			s.logger.Error("error adding instance to cluster during instance processing",
+				zap.String("account_id", s.Account.AccountID),
+				zap.String("cluster_id", clusterID),
+				zap.String("instance_id", instance.InstanceID),
+				zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
Fix logic error in `aws_stocker_ec2.go` where the `AddInstance` call was nested inside the cluster creation conditional block. 

This caused the scanner to only add the first instance of any cluster and skip all subsequent instances if the cluster already existed in memory.

Key changes:
- Moved `AddInstance` logic outside the `if !IsClusterInAccount` check in `internal/stocker/aws_stocker_ec2.go`.
- Ensures all instances are correctly mapped to their clusters, resolving the issue of under-reported instance counts.


Test code


```go
package stocker

import (
	"testing"

	cp "github.com/RHEcosystemAppEng/cluster-iq/internal/cloud_providers/aws"
	"github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
	"go.uber.org/zap"
)

// TestProcessInstances_Regression verifies that multiple instances belonging
// to the same cluster are all correctly added to the inventory.
func TestProcessInstances_Regression(t *testing.T) {
	logger := zap.NewNop()
	account, _ := inventory.NewAccount("acc-1", "test-account", inventory.AWSProvider, "user", "key")

	// Initialize a dummy connection to avoid panic on GetRegion() logic
	conn, _ := cp.NewAWSConnection("user", "key", "us-east-1")

	stocker := &AWSStocker{
		Account:                  account,
		skipNoOpenShiftInstances: false,
		logger:                   logger,
		conn:                     conn,
	}

	// Define tags for a single cluster
	tags := []inventory.Tag{
		{Key: "kubernetes.io/cluster/test-cluster-abcde", Value: "owned"},
	}

	// Create 2 instances for the same cluster
	instance1 := inventory.Instance{
		InstanceID:       "i-1",
		InstanceName:     "test-cluster-abcde-master-0",
		AvailabilityZone: "us-east-1a",
		Tags:             tags,
		Status:           inventory.Running,
	}

	instance2 := inventory.Instance{
		InstanceID:       "i-2",
		InstanceName:     "test-cluster-abcde-worker-0",
		AvailabilityZone: "us-east-1b",
		Tags:             tags,
		Status:           inventory.Running,
	}

	inputInstances := []inventory.Instance{instance1, instance2}

	// Execution
	stocker.processInstances(inputInstances)

	// Verification
	if len(stocker.Account.Clusters) != 1 {
		t.Fatalf("Expected 1 cluster, got %d", len(stocker.Account.Clusters))
	}

	clusterID := "test-cluster-abcde"
	cluster, ok := stocker.Account.Clusters[clusterID]
	if !ok {
		t.Fatalf("Expected cluster %s to exist in account", clusterID)
	}

	// Ensure both instances are present
	if len(cluster.Instances) != 2 {
		t.Errorf("Regression: Expected 2 instances, found %d. Instances are being skipped.", len(cluster.Instances))
	}
}
```