### PR TITLE
fix: cluster age calculation

### DIFF
--- a/internal/inventory/cluster.go
+++ b/internal/inventory/cluster.go
@@ -127,6 +127,8 @@ func (c *Cluster) Update() error {
 // UpdateAge updates cluster age based on the oldest instance creation timestamp. The cluster will be considered as old as the oldest instance
 func (c *Cluster) UpdateAge() error {
 	creationTS := time.Now()
+
+	// Getting oldest creation timestamp
 	for _, instance := range c.Instances {
 		if instance.CreatedAt.Before(creationTS) {
 			creationTS = instance.CreatedAt
@@ -135,7 +137,7 @@ func (c *Cluster) UpdateAge() error {
 	c.CreatedAt = creationTS
 
 	// Calculating Age in days since the cluster was created until last scraping
-	newAge := calculateAge(c.CreatedAt, c.LastScanTimestamp)
+	newAge := calculateAge(c.CreatedAt, time.Now())
 	if c.Age > newAge && c.Age != 0 {
 		return fmt.Errorf("%s. Current age: %d, New estimated age: %d", ErrorNewClusterAge, c.Age, newAge)
 	}

--- a/internal/inventory/cluster_test.go
+++ b/internal/inventory/cluster_test.go
@@ -128,136 +128,204 @@ func testIsClusterRunning_Terminated(t *testing.T) {
 	assert.False(t, cluster.IsClusterRunning())
 }
 
-// TestUpdate tests the Update function including Age and Status updates
-func TestUpdate(t *testing.T) {
-	t.Run("UpdateAge", func(t *testing.T) { testUpdate_Correct(t) })
-	t.Run("UpdateAge Lower New Age", func(t *testing.T) { testUpdate_NewerAge(t) })
+// TestCluster_Update covers Cluster.Update() behavior, including status update,
+// age update, and error propagation from UpdateAge().
+func TestCluster_Update(t *testing.T) {
+	t.Run("success updates status and age", testCluster_Update_SuccessUpdatesStatusAndAge)
+	t.Run("error from UpdateAge is returned and status is still updated", testCluster_Update_ErrorFromUpdateAgeIsReturnedAndStatusIsStillUpdated)
 }
 
-func testUpdate_Correct(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
+// testCluster_Update_SuccessUpdatesStatusAndAge validates that Update() updates both status and age.
+// It also verifies CreatedAt is set to the oldest instance creation timestamp.
+func testCluster_Update_SuccessUpdatesStatusAndAge(t *testing.T) {
+	c := testClusterWithInstances(
+		Instance{Status: Stopped, CreatedAt: time.Now().Add(-48 * time.Hour)},
+		Instance{Status: Terminated, CreatedAt: time.Now().Add(-24 * time.Hour)},
+	)
 
-	err = cluster.Update()
-	assert.Nil(t, err)
+	// status must become Stopped (no Running, not all Terminated).
+	// CreatedAt must be the oldest instance timestamp.
+	expectedCreatedAt := c.Instances[0].CreatedAt
+	expectedAge := calculateAge(expectedCreatedAt, time.Now())
+
+	err := c.Update()
+	assert.NoError(t, err)
+	assert.Equal(t, Stopped, c.Status)
+	assert.True(t, c.CreatedAt.Equal(expectedCreatedAt))
+	assert.Equal(t, expectedAge, c.Age)
 }
 
-func testUpdate_NewerAge(t *testing.T) {
-	prevAge := 30
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
-	t1 := time.Now()
-	t2 := t1.Add(-12 * 24 * time.Hour)
-	cluster.Instances = []Instance{
-		{CreatedAt: t1},
-		{CreatedAt: t2},
-	}
+// testCluster_Update_ErrorFromUpdateAgeIsReturnedAndStatusIsStillUpdated validates that Update()
+// returns UpdateAge() error, but still updates status beforehand.
+func testCluster_Update_ErrorFromUpdateAgeIsReturnedAndStatusIsStillUpdated(t *testing.T) {
+	oldest := time.Now().Add(-48 * time.Hour)
 
-	cluster.Age = prevAge
-	err = cluster.Update()
+	c := testClusterWithInstances(
+		Instance{Status: Running, CreatedAt: oldest}, // Forces early Running status
+		Instance{Status: Stopped, CreatedAt: time.Now().Add(-24 * time.Hour)},
+	)
+
+	// force the "new estimated age is lower" error branch.
+	newAge := calculateAge(oldest, time.Now())
+	c.Age = newAge + 10
+
+	err := c.Update()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, ErrorNewClusterAge.Error())
+
+	// UpdateStatus runs before UpdateAge, so status must be updated even on error.
+	assert.Equal(t, Running, c.Status)
+
+	// UpdateAge sets CreatedAt before comparing ages, so CreatedAt is still updated.
+	assert.True(t, c.CreatedAt.Equal(oldest))
+
+	// on error, Age must remain unchanged (the assignment happens after the check).
+	assert.Equal(t, newAge+10, c.Age)
 }
 
-// TestUpdateAge tests UpdateAge function
-func TestUpdateAge(t *testing.T) {
-	t.Run("UpdateAge", func(t *testing.T) { testUpdateAge_Correct(t) })
-	t.Run("UpdateAge Lower New Age", func(t *testing.T) { testUpdateAge_NewerAge(t) })
+// TestCluster_UpdateAge covers Cluster.UpdateAge() behavior, including empty clusters,
+// selecting the oldest instance timestamp, and the "age regression" error.
+func TestCluster_UpdateAge(t *testing.T) {
+	t.Run("empty cluster sets CreatedAt to now and Age to 1", testCluster_UpdateAge_EmptyClusterSetsCreatedAtToNowAndAgeTo0)
+	t.Run("sets CreatedAt to oldest instance and updates Age", testCluster_UpdateAge_SetsCreatedAtToOldestInstanceAndUpdatesAge)
+	t.Run("returns error when current Age is greater than newly estimated Age and Age != 0", testCluster_UpdateAge_ReturnsErrorOnAgeRegression)
 }
 
-func testUpdateAge_Correct(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
-	t1 := time.Now()
-	t2 := t1.Add(-12 * 24 * time.Hour)
-	cluster.Instances = []Instance{
-		{CreatedAt: t1},
-		{CreatedAt: t2},
-	}
+// testCluster_UpdateAge_EmptyClusterSetsCreatedAtToNowAndAgeTo0 validates UpdateAge() behavior
+// when the cluster has no instances.
+func testCluster_UpdateAge_EmptyClusterSetsCreatedAtToNowAndAgeTo0(t *testing.T) {
+	c := &Cluster{}
 
-	err = cluster.UpdateAge()
-	assert.Nil(t, err)
-	assert.Equal(t, cluster.CreatedAt, t2)
-	assert.Equal(t, cluster.Age, 11)
+	err := c.UpdateAge()
+	assert.NoError(t, err)
+
+	// with no instances, CreatedAt starts as time.Now() and Age becomes 0 days.
+	assert.Equal(t, 1, c.Age)
+	assert.False(t, c.CreatedAt.IsZero())
 }
 
-func testUpdateAge_NewerAge(t *testing.T) {
-	prevAge := 30
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
-	t1 := time.Now()
-	t2 := t1.Add(-12 * 24 * time.Hour)
-	cluster.Instances = []Instance{
-		{CreatedAt: t1},
-		{CreatedAt: t2},
-	}
-	cluster.Age = prevAge
+// testCluster_UpdateAge_SetsCreatedAtToOldestInstanceAndUpdatesAge validates that UpdateAge()
+// uses the oldest instance creation timestamp and updates cluster age accordingly.
+func testCluster_UpdateAge_SetsCreatedAtToOldestInstanceAndUpdatesAge(t *testing.T) {
+	oldest := time.Now().Add(-72 * time.Hour)
+	newer := time.Now().Add(-24 * time.Hour)
 
-	err = cluster.UpdateAge()
+	c := testClusterWithInstances(
+		Instance{Status: Stopped, CreatedAt: newer},
+		Instance{Status: Stopped, CreatedAt: oldest},
+	)
+
+	expectedAge := calculateAge(oldest, time.Now())
+
+	err := c.UpdateAge()
+	assert.NoError(t, err)
+
+	// CreatedAt must reflect the oldest node in the cluster.
+	assert.True(t, c.CreatedAt.Equal(oldest))
+
+	// Age is recalculated using CreatedAt and the scrape time (time.Now()).
+	assert.Equal(t, expectedAge, c.Age)
+}
+
+// testCluster_UpdateAge_ReturnsErrorOnAgeRegression validates that UpdateAge() fails when it detects
+// a regression in age (newly estimated Age is lower than the current Age), and Age != 0.
+func testCluster_UpdateAge_ReturnsErrorOnAgeRegression(t *testing.T) {
+	oldest := time.Now().Add(-48 * time.Hour)
+
+	c := testClusterWithInstances(
+		Instance{Status: Stopped, CreatedAt: oldest},
+	)
+
+	newAge := calculateAge(oldest, time.Now())
+	c.Age = newAge + 1 // Force regression
+
+	err := c.UpdateAge()
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, ErrorNewClusterAge.Error())
-	assert.NotZero(t, cluster.CreatedAt)
-	assert.Equal(t, cluster.Age, prevAge)
+
+	// CreatedAt is assigned before the regression check.
+	assert.True(t, c.CreatedAt.Equal(oldest))
+
+	// on error, Age must remain the previous value.
+	assert.Equal(t, newAge+1, c.Age)
 }
 
-// TestUpdateStatus tests the UpdateStatus function
-func TestUpdateStatus(t *testing.T) {
-	t.Run("UpdateStatus no Instances", func(t *testing.T) { testUpdateStatus_NoInstances(t) })
-	t.Run("UpdateStatus at lease one Instance Running", func(t *testing.T) { testUpdateStatus_AtLeastOneInstanceRunning(t) })
-	t.Run("UpdateStatus all Instances Terminated", func(t *testing.T) { testUpdateStatus_TerminatedInstances(t) })
-	t.Run("UpdateStatus mix Stopped and Terminated", func(t *testing.T) { testUpdateStatus_NoInstancesRunning(t) })
+// TestCluster_UpdateStatus covers Cluster.UpdateStatus() logic for empty clusters,
+// Running early return, all Terminated, and all/mixed Stopped/Terminated.
+func TestCluster_UpdateStatus(t *testing.T) {
+	t.Run("empty cluster -> Terminated", testCluster_UpdateStatus_EmptyClusterTerminated)
+	t.Run("any instance Running -> Running (early return)", testCluster_UpdateStatus_AnyRunningEarlyReturnRunning)
+	t.Run("all instances Terminated -> Terminated", testCluster_UpdateStatus_AllTerminatedTerminated)
+	t.Run("mix of Stopped/Terminated (no Running) -> Stopped", testCluster_UpdateStatus_MixStoppedTerminatedStopped)
+	t.Run("all instances Stopped -> Stopped", testCluster_UpdateStatus_AllStoppedStopped)
 }
 
-func testUpdateStatus_NoInstances(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
+// testCluster_UpdateStatus_EmptyClusterTerminated validates that an empty cluster is marked as Terminated.
+func testCluster_UpdateStatus_EmptyClusterTerminated(t *testing.T) {
+	c := &Cluster{Instances: nil}
 
-	cluster.UpdateStatus()
-	assert.Equal(t, cluster.Status, Terminated)
+	c.UpdateStatus()
+	assert.Equal(t, Terminated, c.Status)
 }
 
-func testUpdateStatus_AtLeastOneInstanceRunning(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.NotNil(t, cluster)
-	assert.Nil(t, err)
-	cluster.Instances = []Instance{
-		{Status: Running},
-		{Status: Stopped},
+// testCluster_UpdateStatus_AnyRunningEarlyReturnRunning validates the early-return rule:
+// any Running instance sets the cluster status to Running.
+func testCluster_UpdateStatus_AnyRunningEarlyReturnRunning(t *testing.T) {
+	c := testClusterWithInstances(
+		Instance{Status: Terminated},
+		Instance{Status: Running}, // Must win
+		Instance{Status: Stopped},
+	)
+
+	c.UpdateStatus()
+	assert.Equal(t, Running, c.Status)
+}
+
+// testCluster_UpdateStatus_AllTerminatedTerminated validates that all Terminated instances
+// result in cluster status Terminated.
+func testCluster_UpdateStatus_AllTerminatedTerminated(t *testing.T) {
+	c := testClusterWithInstances(
+		Instance{Status: Terminated},
+		Instance{Status: Terminated},
+	)
+
+	c.UpdateStatus()
+	assert.Equal(t, Terminated, c.Status)
+}
+
+// testCluster_UpdateStatus_MixStoppedTerminatedStopped validates that a mix of Stopped/Terminated
+// (with no Running instances) results in cluster status Stopped.
+func testCluster_UpdateStatus_MixStoppedTerminatedStopped(t *testing.T) {
+	c := testClusterWithInstances(
+		Instance{Status: Terminated},
+		Instance{Status: Stopped},
+		Instance{Status: Terminated},
+	)
+
+	c.UpdateStatus()
+	assert.Equal(t, Stopped, c.Status)
+}
+
+// testCluster_UpdateStatus_AllStoppedStopped validates that all Stopped instances
+// result in cluster status Stopped.
+func testCluster_UpdateStatus_AllStoppedStopped(t *testing.T) {
+	c := testClusterWithInstances(
+		Instance{Status: Stopped},
+		Instance{Status: Stopped},
+	)
+
+	c.UpdateStatus()
+	assert.Equal(t, Stopped, c.Status)
+}
+
+// testClusterWithInstances builds a Cluster with the provided instances.
+// It keeps tests concise and consistent across scenarios.
+func testClusterWithInstances(instances ...Instance) *Cluster {
+	c := &Cluster{
+		Instances: make([]Instance, 0, len(instances)),
 	}
-
-	cluster.UpdateStatus()
-	assert.Equal(t, cluster.Status, Running)
-}
-
-func testUpdateStatus_TerminatedInstances(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.Nil(t, err)
-	assert.NotNil(t, cluster)
-	cluster.Instances = []Instance{
-		{Status: Terminated},
-		{Status: Terminated},
-	}
-
-	cluster.UpdateStatus()
-	assert.Equal(t, cluster.Status, Terminated)
-}
-
-func testUpdateStatus_NoInstancesRunning(t *testing.T) {
-	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
-	assert.Nil(t, err)
-	assert.NotNil(t, cluster)
-	cluster.Instances = []Instance{
-		{Status: Stopped},
-		{Status: Terminated},
-	}
-
-	cluster.UpdateStatus()
-	assert.Equal(t, cluster.Status, Stopped)
+	c.Instances = append(c.Instances, instances...)
+	return c
 }
 
 // TestAddInstance tests the AddInstance function including repeated instances

--- a/internal/models/dto/cluster_dto.go
+++ b/internal/models/dto/cluster_dto.go
@@ -40,6 +40,7 @@ func (c ClusterDTORequest) ToInventoryCluster() *inventory.Cluster {
 	cluster.CreatedAt = c.CreatedAt
 	cluster.Status = c.Status
 	cluster.AccountID = c.AccountID
+	cluster.Age = c.Age
 
 	return cluster
 }

--- a/internal/stocker/aws_stocker_ec2.go
+++ b/internal/stocker/aws_stocker_ec2.go
@@ -44,30 +44,28 @@ func (s *AWSStocker) processInstances(instances []inventory.Instance) {
 			continue
 		}
 
-		clusterID := inventory.GenerateClusterID(clusterName, infraID)
-		if !s.Account.IsClusterInAccount(clusterID) {
-			cluster, err := inventory.NewCluster(
-				clusterName,
-				infraID,
-				inventory.AWSProvider,
-				s.conn.GetRegion(),
-				unknownConsoleLinkCode,
-				inventory.GetOwnerFromTags(instance.Tags),
-			)
-			if err != nil {
-				s.logger.Error("error creating new cluster during instance processing", zap.Error(err))
-				continue
-			}
+		cluster, err := inventory.NewCluster(
+			clusterName,
+			infraID,
+			inventory.AWSProvider,
+			s.conn.GetRegion(),
+			unknownConsoleLinkCode,
+			inventory.GetOwnerFromTags(instance.Tags),
+		)
 
-			if !s.Account.IsClusterInAccount(cluster.ClusterID) {
-				_ = s.Account.AddCluster(cluster)
-			}
+		if err != nil {
+			s.logger.Error("error creating new cluster during instance processing", zap.Error(err))
+			continue
 		}
 
-		if err := s.Account.Clusters[clusterID].AddInstance(&instance); err != nil {
+		if !s.Account.IsClusterInAccount(cluster.ClusterID) {
+			_ = s.Account.AddCluster(cluster)
+		}
+
+		if err := s.Account.Clusters[cluster.ClusterID].AddInstance(&instance); err != nil {
 			s.logger.Error("error adding instance to cluster during instance processing",
 				zap.String("account_id", s.Account.AccountID),
-				zap.String("cluster_id", clusterID),
+				zap.String("cluster_id", cluster.ClusterID),
 				zap.String("instance_id", instance.InstanceID),
 				zap.Error(err))
 		}


### PR DESCRIPTION
Closes #243 
Fixed cluster age calculation, unit tests and DTO transform function where 'age' parameter was missing