### PR TITLE
refactor(inventory): replace fmt.Printf printing with structured zap logging

### DIFF
--- a/cmd/scanner/scanner.go
+++ b/cmd/scanner/scanner.go
@@ -349,7 +349,11 @@ func (s *Scanner) ExecuteScan(accountIDs []string, selectAll bool) (int, error) 
 		return 0, fmt.Errorf("failed to run stockers: %w", err)
 	}
 
-	inv.PrintInventory()
+	s.logger.Info("Inventory scan complete",
+		zap.Int("accounts", len(inv.Accounts)),
+		zap.Int("clusters", inv.TotalClusters()),
+		zap.Int("instances", inv.TotalInstances()),
+	)
 	if err := postScannerInventory(inv, s.logger); err != nil {
 		return 0, fmt.Errorf("failed to post inventory: %w", err)
 	}

--- a/internal/inventory/account.go
+++ b/internal/inventory/account.go
@@ -130,12 +130,3 @@ func (a *Account) DisableBilling() {
 func (a *Account) IsBillingEnabled() bool {
 	return a.billingEnabled
 }
-
-// PrintAccount prints account info and every cluster on it by stdout
-func (a Account) PrintAccount() {
-	fmt.Printf("\t - Account: %s[%s] #Clusters: %d\n", a.AccountName, a.AccountID, len(a.Clusters))
-
-	for _, cluster := range a.Clusters {
-		cluster.PrintCluster()
-	}
-}

--- a/internal/inventory/account_test.go
+++ b/internal/inventory/account_test.go
@@ -207,27 +207,3 @@ func testIsBillingEnabled_False(t *testing.T) {
 	assert.False(t, account.billingEnabled, account.IsBillingEnabled())
 }
 
-func TestPrintAccount(t *testing.T) {
-	t.Run("Print Account ", func(t *testing.T) { testPrintAccount_Correct(t) })
-	t.Run("Print Account No clusters", func(t *testing.T) { testPrintAccount_NoClusters(t) })
-}
-
-func testPrintAccount_Correct(t *testing.T) {
-	account, err := NewAccount("0000-11A", "testAccount", AWSProvider, "user", "password")
-	assert.Nil(t, err)
-	assert.NotNil(t, account)
-
-	cluster, err := NewCluster("testCluster-1", "XXXX1", AWSProvider, "eu-west-1", "https://url.com", "John Doe")
-	assert.Nil(t, err)
-	account.AddCluster(cluster)
-
-	account.PrintAccount()
-}
-
-func testPrintAccount_NoClusters(t *testing.T) {
-	account, err := NewAccount("0000-11A", "testAccount", AWSProvider, "user", "password")
-	assert.Nil(t, err)
-	assert.NotNil(t, account)
-
-	account.PrintAccount()
-}

--- a/internal/inventory/cluster.go
+++ b/internal/inventory/cluster.go
@@ -224,12 +224,3 @@ func (c Cluster) InstancesCount() int {
 func GenerateClusterID(name string, infraID string) string {
 	return name + "-" + infraID
 }
-
-// PrintCluster prints cluster info
-func (c Cluster) PrintCluster() {
-	fmt.Printf("\t\tCluster:[%s] -- Status: %s, Region: %s, Provider: %s, #Instances: %d\n", c.ClusterName, c.Status, c.Region, c.Provider, c.InstancesCount())
-
-	for _, instance := range c.Instances {
-		instance.PrintInstance()
-	}
-}

--- a/internal/inventory/cluster_test.go
+++ b/internal/inventory/cluster_test.go
@@ -412,7 +412,7 @@ func testInstancesCount(t *testing.T) {
 	cluster, err := NewCluster("testCluster", "i1", AWSProvider, "us-east-1", "https://console", "user")
 	assert.NotNil(t, cluster)
 	assert.Nil(t, err)
-	assert.Equal(t, len(cluster.Instances), 0)
+	assert.Equal(t, 0, cluster.InstancesCount())
 }
 
 // TestGenerateClusterID tests GenerateClusterID function for 100% coverage
@@ -420,14 +420,3 @@ func TestGenerateClusterID(t *testing.T) {
 	assert.Equal(t, "test-infra", GenerateClusterID("test", "infra"))
 }
 
-// TestPrintCluster tests PrintCluster function for 100% coverage
-func TestPrintCluster(t *testing.T) {
-	c, _ := NewCluster("name", "infra", AWSProvider, "region", "link", "owner")
-	c.PrintCluster()
-
-	now := time.Now()
-	c.Instances = []Instance{
-		{Status: Running, CreatedAt: now.Add(-24 * time.Hour)},
-	}
-	c.PrintCluster()
-}

--- a/internal/inventory/instance.go
+++ b/internal/inventory/instance.go
@@ -2,7 +2,6 @@ package inventory
 
 import (
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -109,22 +108,4 @@ func (i *Instance) AddExpense(expense *Expense) error {
 	i.Expenses = append(i.Expenses, *expense)
 
 	return nil
-}
-
-// String as ToString func
-func (i Instance) String() string {
-	return fmt.Sprintf("(%s): [%s][%s][%s][%s][%s][%d]",
-		i.InstanceName,
-		i.Provider,
-		i.InstanceType,
-		i.AvailabilityZone,
-		i.Status,
-		i.ClusterID,
-		len(i.Expenses),
-	)
-}
-
-// PrintInstance prints Instance details
-func (i Instance) PrintInstance() {
-	fmt.Printf("\t\t\tInstance: %s\n", i.String())
 }

--- a/internal/inventory/instance_test.go
+++ b/internal/inventory/instance_test.go
@@ -1,7 +1,6 @@
 package inventory
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -125,27 +124,3 @@ func testAddExpense_WithNegativeAmount(t *testing.T) {
 	assert.Zero(t, len(i.Tags))
 }
 
-// TestInstance_String verifies String method returns expected format
-func TestInstance_String(t *testing.T) {
-	i := Instance{
-		InstanceID:       "i-123",
-		InstanceName:     "test",
-		Provider:         AWSProvider,
-		InstanceType:     "t2.micro",
-		AvailabilityZone: "us-east-1a",
-		Status:           Running,
-		ClusterID:        "cluster-x",
-		Expenses:         []Expense{{Amount: 5}},
-	}
-
-	str := i.String()
-	if !(strings.Contains(str, "test") && strings.Contains(str, "AWS") && strings.Contains(str, "t2.micro")) {
-		t.Errorf("unexpected output from String(): %s", str)
-	}
-}
-
-// TestPrintInstance verifies PrintInstance runs without panic
-func TestPrintInstance(t *testing.T) {
-	i := Instance{InstanceID: "i-456", InstanceName: "node1"}
-	i.PrintInstance()
-}

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -44,10 +44,22 @@ func (i *Inventory) AddAccount(account *Account) error {
 	return nil
 }
 
-// PrintInventory prints the entire Inventory content
-func (i Inventory) PrintInventory() {
-	fmt.Printf("Inventory created at: %s\nAccounts:\n", i.CreatedAt)
+// TotalClusters returns the total number of clusters across all accounts
+func (i Inventory) TotalClusters() int {
+	total := 0
 	for _, account := range i.Accounts {
-		account.PrintAccount()
+		total += len(account.Clusters)
 	}
+	return total
+}
+
+// TotalInstances returns the total number of instances across all accounts and clusters
+func (i Inventory) TotalInstances() int {
+	total := 0
+	for _, account := range i.Accounts {
+		for _, cluster := range account.Clusters {
+			total += len(cluster.Instances)
+		}
+	}
+	return total
 }

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -79,15 +79,42 @@ func testAddAccount_Repeated(t *testing.T) {
 	assert.ErrorContains(t, err, ErrorAddingAccountToInventory.Error())
 }
 
-func TestPrintInventory(t *testing.T) {
+func TestTotalClusters(t *testing.T) {
 	inv := NewInventory()
-	acc := Account{
-		AccountID:   "id-account",
-		AccountName: "testAccount",
-		Provider:    UnknownProvider,
-	}
 
-	inv.AddAccount(&acc)
+	acc1 := &Account{AccountID: "acc-1", Clusters: map[string]*Cluster{
+		"c1": {ClusterID: "c1"},
+		"c2": {ClusterID: "c2"},
+	}}
+	acc2 := &Account{AccountID: "acc-2", Clusters: map[string]*Cluster{
+		"c3": {ClusterID: "c3"},
+	}}
 
-	inv.PrintInventory()
+	inv.AddAccount(acc1)
+	inv.AddAccount(acc2)
+
+	assert.Equal(t, 3, inv.TotalClusters())
+}
+
+func TestTotalInstances(t *testing.T) {
+	inv := NewInventory()
+
+	acc := &Account{AccountID: "acc-1", Clusters: map[string]*Cluster{
+		"c1": {ClusterID: "c1", Instances: []Instance{{InstanceID: "i1"}, {InstanceID: "i2"}}},
+		"c2": {ClusterID: "c2", Instances: []Instance{{InstanceID: "i3"}}},
+	}}
+
+	inv.AddAccount(acc)
+
+	assert.Equal(t, 3, inv.TotalInstances())
+}
+
+func TestTotalClusters_Empty(t *testing.T) {
+	inv := NewInventory()
+	assert.Equal(t, 0, inv.TotalClusters())
+}
+
+func TestTotalInstances_Empty(t *testing.T) {
+	inv := NewInventory()
+	assert.Equal(t, 0, inv.TotalInstances())
 }

--- a/internal/stocker/aws_billing_stocker.go
+++ b/internal/stocker/aws_billing_stocker.go
@@ -162,11 +162,6 @@ func (s *AWSBillingStocker) getInstanceExpenses(instance *inventory.Instance) er
 	return nil
 }
 
-// PrintStock prints the stock (account) of the AWSBillingStocker as a string
-func (s AWSBillingStocker) PrintStock() {
-	s.Account.PrintAccount()
-}
-
 // GetAccount returns the account configured for this stocker
 func (s AWSBillingStocker) GetAccount() inventory.Account {
 	return *s.Account

--- a/internal/stocker/aws_stocker.go
+++ b/internal/stocker/aws_stocker.go
@@ -71,11 +71,6 @@ func (s *AWSStocker) MakeStock() error {
 	return nil
 }
 
-// PrintStock Prints the Account Stock
-func (s AWSStocker) PrintStock() {
-	s.Account.PrintAccount()
-}
-
 // GetAccount Returns the Account was scanned on this stocker
 func (s AWSStocker) GetAccount() inventory.Account {
 	return *s.Account

--- a/internal/stocker/azure_stocker.go
+++ b/internal/stocker/azure_stocker.go
@@ -26,11 +26,6 @@ func (s AzureStocker) MakeStock() error {
 	return fmt.Errorf("AzureStocker.MakeStock not implemented")
 }
 
-// PrintStock prints by stdout the account object belongs to this stocker
-func (s AzureStocker) PrintStock() {
-	s.Account.PrintAccount()
-}
-
 // GetAccount resturns the scanned results on this stocker instance
 func (s AzureStocker) GetAccount() inventory.Account {
 	return s.Account

--- a/internal/stocker/gcp_stocker.go
+++ b/internal/stocker/gcp_stocker.go
@@ -26,11 +26,6 @@ func (s GCPStocker) MakeStock() error {
 	return fmt.Errorf("GCPStocker.MakeStock not implemented")
 }
 
-// PrintStock prints by stdout the account object belongs to this stocker
-func (s GCPStocker) PrintStock() {
-	s.Account.PrintAccount()
-}
-
 // GetAccount resturns the scanned results on this stocker instance
 func (s GCPStocker) GetAccount() inventory.Account {
 	return s.Account

--- a/internal/stocker/stocker.go
+++ b/internal/stocker/stocker.go
@@ -5,6 +5,5 @@ import "github.com/RHEcosystemAppEng/cluster-iq/internal/inventory"
 // Stocker interface
 type Stocker interface {
 	MakeStock() error
-	PrintStock()
 	GetAccount() inventory.Account
 }


### PR DESCRIPTION
## Summary

- Remove all `Print*` and `String()` methods from the `inventory` package — `fmt.Printf` side effects don't belong in domain models
- Remove `PrintStock()` from the `Stocker` interface and all implementations (AWS, GCP, Azure) — it was never called
- Add `TotalClusters()` and `TotalInstances()` helper methods to `Inventory`
- Replace `inv.PrintInventory()` in the scanner with structured `zap.Info` logging with account/cluster/instance counts

## Test plan

- [x] `make go-unit-tests` — all pass, 100% coverage on inventory
- [x] `make lint` — 0 issues
- [x] `make local-build` — compiles clean

Closes #242