### PR TITLE
chore(agent): replace stdlib log with zap in gRPC interceptor

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -194,14 +193,14 @@ func LoggingInterceptor(
 		logger.Info("Client connected", zap.String("ip", p.Addr.String()))
 	}
 
-	log.Printf("Invoked method: %s", info.FullMethod)
+	logger.Info("Invoked method", zap.String("method", info.FullMethod))
 
 	resp, err := handler(ctx, req)
 
 	if err != nil {
-		log.Printf("Error in method %s: %v", info.FullMethod, err)
+		logger.Error("Method failed", zap.String("method", info.FullMethod), zap.Error(err))
 	} else {
-		log.Printf("Method %s executed successfully", info.FullMethod)
+		logger.Info("Method executed successfully", zap.String("method", info.FullMethod))
 	}
 
 	return resp, err


### PR DESCRIPTION
## Summary

- Replace the last 3 `log.Printf` calls in the gRPC `LoggingInterceptor` with structured `zap` logging
- Remove the stdlib `log` import from `cmd/agent/agent.go`
- The entire codebase now uses `zap` consistently — no stdlib `log` remains

## Test plan

- [x] `make local-build` — compiles clean
- [x] `make lint` — 0 issues
- [x] Verified no remaining `log.Print*` or `"log"` imports in `cmd/` or `internal/`

Closes #114